### PR TITLE
Added image upload options throughout app

### DIFF
--- a/src/tt/apps/images/services.py
+++ b/src/tt/apps/images/services.py
@@ -500,7 +500,7 @@ class ImageUploadService(Singleton):
 
             return ImageUploadResult.success(
                 filename=uploaded_file.name,
-                uuid=str(trip_image.uuid),
+                trip_image=trip_image,
                 metadata=metadata,
                 html=html,
             )

--- a/src/tt/apps/images/templates/images/modals/entity_image_picker.html
+++ b/src/tt/apps/images/templates/images/modals/entity_image_picker.html
@@ -10,6 +10,9 @@ Context variables required:
 - accessible_images: QuerySet of TripImage instances
 - selected_date: Date object for current filter
 
+Optional context variables:
+- upload_url: URL for image upload modal (displays upload button if provided)
+
 Subclasses must define these blocks:
 - modal_dialog_id: Unique ID for the modal
 - title_text: Modal title
@@ -71,10 +74,20 @@ Subclasses must define these blocks:
 
     <!-- Date Filter Section -->
     <div class="form-group mb-0">
-      <label for="date-filter" class="font-weight-bold">
-        {% icon "calendar" size="sm" css_class="tt-icon-left" %}
-        Filter by Date
-      </label>
+      <div class="d-flex justify-content-between align-items-center mb-2">
+        <label for="date-filter" class="font-weight-bold mb-0">
+          {% icon "calendar" size="sm" css_class="tt-icon-left" %}
+          Filter by Date
+        </label>
+        {% if upload_url %}
+        <a href="{{ upload_url }}"
+           class="btn btn-sm btn-outline-primary"
+           data-async="modal">
+          {% icon "upload" size="sm" css_class="tt-icon-left" %}
+          Upload
+        </a>
+        {% endif %}
+      </div>
       <input type="date"
              id="date-filter"
              name="date"

--- a/src/tt/apps/images/templates/images/modals/entity_image_upload.html
+++ b/src/tt/apps/images/templates/images/modals/entity_image_upload.html
@@ -1,0 +1,143 @@
+{% extends "modals/action_2_with_cancel.html" %}
+{% load icons %}
+{% load static %}
+
+{% comment %}
+Base image upload modal for uploading images in modal context.
+
+This template provides a reusable upload interface that can be used for:
+- Multi-image uploads (e.g., Journal Entry editing)
+- Single-image uploads (e.g., Trip reference image setting)
+
+Context variables required:
+- upload_url: URL for form action and upload endpoint
+- max_files: Maximum number of files to allow (default: 50, use 1 for single-image mode)
+- heif_support_available: Boolean indicating HEIF format support
+- upload_zone_id: Unique ID for the upload zone
+- file_input_id: Unique ID for the file input
+
+Optional context variables:
+- show_uploaded_grid: Whether to show uploaded images grid (default: True)
+- uploaded_images: QuerySet of TripImage instances to display initially
+- initial_uploaded_count: Initial count of uploaded images (default: 0)
+
+Subclasses must define these blocks:
+- modal_dialog_id: Unique ID for the modal
+- title_text: Modal title
+{% endcomment %}
+
+{% block modal_dialog_class %}tt-modal-dialog-800{% endblock %}
+
+{% block preamble %}
+<form method="post"
+      action="{{ upload_url }}"
+      data-async="modal"
+      id="image-upload-form">
+  {% csrf_token %}
+{% endblock %}
+
+{% block body %}
+  <!-- HEIC Support Warning -->
+  {% if not heif_support_available %}
+  <div class="alert alert-warning" role="alert">
+    <strong>Limited Format Support:</strong> HEIC/iPhone image format is not available.
+    Only JPG and PNG formats are supported.
+  </div>
+  {% endif %}
+
+  <!-- Upload Zone -->
+  <div class="upload-zone" id="{{ upload_zone_id }}">
+    <div class="upload-icon">
+      {% icon "upload" size="xl" %}
+    </div>
+    <h2 class="upload-title">Drag & Drop Photos Here</h2>
+    <p class="upload-subtitle">or</p>
+    <button class="btn btn-upload" type="button" onclick="document.getElementById('{{ file_input_id }}').click()">
+      Choose Files from Computer
+    </button>
+    <p class="upload-hint">
+      Supports JPG, PNG{% if heif_support_available %}, HEIC{% endif %} • Max 20MB per file
+      {% if max_files == 1 %}
+        • Single image only
+      {% else %}
+        • Multiple files allowed (max {{ max_files }})
+      {% endif %}
+    </p>
+    <input type="file"
+           id="{{ file_input_id }}"
+           {% if max_files == 1 %}{% else %}multiple{% endif %}
+           accept="image/jpeg,image/jpg,image/png{% if heif_support_available %},image/heic{% endif %}"
+           style="display: none;">
+  </div>
+
+  <!-- Upload Progress Section -->
+  <div class="upload-progress-section" id="{{ upload_zone_id }}-progress-section" style="display: none;">
+    <div class="progress-header">
+      <h3 class="progress-title">Uploading</h3>
+      <span class="progress-count" id="{{ upload_zone_id }}-progress-count">0 of 0 files</span>
+    </div>
+    <div id="{{ upload_zone_id }}-file-progress-list"></div>
+  </div>
+
+  <!-- Uploaded Images Grid -->
+  {% if show_uploaded_grid %}
+  <div class="uploaded-section">
+    <div class="uploaded-header">
+      <h3 class="uploaded-title">Uploaded Photos</h3>
+      <span class="uploaded-count" id="{{ upload_zone_id }}-uploaded-count">{{ initial_uploaded_count|default:0 }}</span>
+    </div>
+
+    <div class="uploaded-grid" id="{{ upload_zone_id }}-uploaded-grid">
+      {% if uploaded_images %}
+        {% for image in uploaded_images %}
+        {% include "images/components/image_grid_item.html" with trip_image=image %}
+        {% endfor %}
+      {% else %}
+        <div class="empty-state">
+          <div class="empty-state-icon">{% icon "camera" size="xl" %}</div>
+          <p>No photos uploaded yet. Upload some photos to get started!</p>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+  {% endif %}
+{% endblock %}
+
+{% block action_right %}
+<button type="button"
+        class="btn btn-primary"
+        data-dismiss="modal">
+  {% icon "save" size="sm" css_class="tt-icon-left" %}
+  DONE
+</button>
+{% endblock %}
+
+{% block postamble %}
+</form>
+
+<script>
+$(document).ready(function() {
+    // Initialize the upload component with configuration
+    Tt.createImageUpload({
+        uploadZoneSelector: '#{{ upload_zone_id }}',
+        fileInputSelector: '#{{ file_input_id }}',
+        progressSectionSelector: '#{{ upload_zone_id }}-progress-section',
+        progressCountSelector: '#{{ upload_zone_id }}-progress-count',
+        fileProgressListSelector: '#{{ upload_zone_id }}-file-progress-list',
+        {% if show_uploaded_grid %}
+        uploadedGridSelector: '#{{ upload_zone_id }}-uploaded-grid',
+        uploadedCountSelector: '#{{ upload_zone_id }}-uploaded-count',
+        {% endif %}
+        uploadEndpoint: '{{ upload_url }}',
+        maxFiles: {{ max_files|default:50 }}{% if max_files == 1 %},
+        onComplete: function(results) {
+            // Single-image mode: refresh page on successful upload
+            if (results.length > 0 && results[0].status === 'success') {
+                location.reload();
+            }
+        }
+        {% endif %}
+    });
+});
+</script>
+{% endblock %}

--- a/src/tt/apps/images/templates/images/pages/trip_images_home.html
+++ b/src/tt/apps/images/templates/images/pages/trip_images_home.html
@@ -69,7 +69,17 @@
 {% block footer_post_javascript %}
 <script>
 $(document).ready(function() {
-    Tt.tripImagesUpload.init();
+    // Initialize upload component using the configurable factory
+    Tt.createImageUpload({
+        uploadZoneSelector: '#{{ DIVID.IMAGES_UPLOAD_ZONE_ID }}',
+        fileInputSelector: '#{{ DIVID.IMAGES_FILE_INPUT_ID }}',
+        progressSectionSelector: '#{{ DIVID.IMAGES_PROGRESS_SECTION_ID }}',
+        progressCountSelector: '#{{ DIVID.IMAGES_PROGRESS_COUNT_ID }}',
+        fileProgressListSelector: '#{{ DIVID.IMAGES_FILE_PROGRESS_LIST_ID }}',
+        uploadedGridSelector: '#{{ DIVID.IMAGES_UPLOADED_GRID_ID }}',
+        uploadedCountSelector: '#{{ DIVID.IMAGES_UPLOADED_COUNT_ID }}',
+        maxFiles: 50
+    });
 });
 </script>
 {% endblock %}

--- a/src/tt/apps/journal/templates/journal/components/journal_entry_image_picker.html
+++ b/src/tt/apps/journal/templates/journal/components/journal_entry_image_picker.html
@@ -3,7 +3,15 @@
 
 <!-- Panel Header - Fixed -->
 <div class="{{ DIVID.JOURNAL_IMAGE_PANEL_HEADER_CLASS }}">
-  <h5 class="mb-2">Images</h5>
+  <div class="d-flex justify-content-between align-items-center mb-2">
+    <h5 class="mb-0">Images</h5>
+    <a href="{% url 'journal_entry_image_upload' entry_uuid=entry.uuid %}"
+       class="btn btn-sm btn-outline-primary"
+       data-async="modal">
+      {% icon "upload" size="sm" css_class="tt-icon-left" %}
+      Upload
+    </a>
+  </div>
 
   <!-- Date and Scope Filter Form -->
   <form method="get" action="{% url 'journal_entry_images' entry_uuid=entry.uuid %}" data-async="#journal-image-gallery" data-mode="insert">

--- a/src/tt/apps/journal/templates/journal/modals/journal_entry_image_upload.html
+++ b/src/tt/apps/journal/templates/journal/modals/journal_entry_image_upload.html
@@ -1,0 +1,20 @@
+{% extends "images/modals/entity_image_upload.html" %}
+
+{% block modal_dialog_id %}journal-entry-image-upload-modal{% endblock %}
+{% block title_text %}Upload Images{% endblock %}
+
+{% comment %}
+Multi-image upload modal for Journal Entry context.
+Overrides the DONE button to refresh the page when closed,
+so newly uploaded images appear in the image picker gallery.
+{% endcomment %}
+
+{% block action_right %}
+<button type="button"
+        class="btn btn-primary"
+        onclick="location.reload();">
+  {% load icons %}
+  {% icon "save" size="sm" css_class="tt-icon-left" %}
+  DONE
+</button>
+{% endblock %}

--- a/src/tt/apps/journal/templates/journal/modals/journal_image_upload.html
+++ b/src/tt/apps/journal/templates/journal/modals/journal_image_upload.html
@@ -1,0 +1,4 @@
+{% extends "images/modals/entity_image_upload.html" %}
+
+{% block modal_dialog_id %}journal-image-upload-modal{% endblock %}
+{% block title_text %}Upload Journal Image{% endblock %}

--- a/src/tt/apps/journal/urls.py
+++ b/src/tt/apps/journal/urls.py
@@ -54,6 +54,11 @@ urlpatterns = [
         name='journal_reference_image_picker'
     ),
     path(
+        '<uuid:journal_uuid>/upload-image/',
+        views.JournalImageUploadView.as_view(),
+        name='journal_image_upload'
+    ),
+    path(
         '<uuid:journal_uuid>/entry/new/',
         views.JournalEntryNewView.as_view(),
         name='journal_entry_new'
@@ -77,6 +82,11 @@ urlpatterns = [
         'entry/<uuid:entry_uuid>/images/',
         views.JournalEntryImagePickerView.as_view(),
         name='journal_entry_images'
+    ),
+    path(
+        'entry/<uuid:entry_uuid>/upload-images/',
+        views.JournalEntryImageUploadView.as_view(),
+        name='journal_entry_image_upload'
     ),
     path(
         'entry/editor-help',

--- a/src/tt/apps/trips/templates/trips/modals/trip_image_upload.html
+++ b/src/tt/apps/trips/templates/trips/modals/trip_image_upload.html
@@ -1,0 +1,4 @@
+{% extends "images/modals/entity_image_upload.html" %}
+
+{% block modal_dialog_id %}trip-image-upload-modal{% endblock %}
+{% block title_text %}Upload Trip Image{% endblock %}

--- a/src/tt/apps/trips/urls.py
+++ b/src/tt/apps/trips/urls.py
@@ -24,4 +24,9 @@ urlpatterns = [
         views.TripReferenceImagePickerView.as_view(),
         name='trip_reference_image_picker'
     ),
+    path(
+        '<uuid:trip_uuid>/upload-image/',
+        views.TripImageUploadView.as_view(),
+        name='trip_image_upload'
+    ),
 ]

--- a/src/tt/static/css/trip_images.css
+++ b/src/tt/static/css/trip_images.css
@@ -47,7 +47,9 @@
   background-color: rgba(23, 112, 114, 0.02);
 }
 
-.upload-zone.dragover {
+/* Support both old 'dragover' and new 'tt-upload-dragover' class names */
+.upload-zone.dragover,
+.upload-zone.tt-upload-dragover {
   border-color: var(--primary-color);
   background-color: rgba(23, 112, 114, 0.05);
   border-width: 4px;
@@ -132,9 +134,11 @@
 
 /* ========================================
    Individual File Progress
+   Support both old and new (tt-) prefixed class names
    ======================================== */
 
-.file-progress-item {
+.file-progress-item,
+.tt-file-progress-item {
   padding: 1rem;
   border: 1px solid #f0f0f0;
   border-radius: 8px;
@@ -142,34 +146,40 @@
   transition: all 0.2s ease;
 }
 
-.file-progress-item.uploading {
+.file-progress-item.uploading,
+.tt-file-progress-item.uploading {
   background: rgba(23, 112, 114, 0.02);
   border-color: var(--primary-color);
 }
 
-.file-progress-item.processing {
+.file-progress-item.processing,
+.tt-file-progress-item.processing {
   background: rgba(23, 112, 114, 0.02);
   border-color: var(--primary-color);
 }
 
-.file-progress-item.success {
+.file-progress-item.success,
+.tt-file-progress-item.success {
   background: rgba(23, 114, 25, 0.02);
   border-color: var(--success-color);
 }
 
-.file-progress-item.error {
+.file-progress-item.error,
+.tt-file-progress-item.error {
   background: rgba(114, 24, 23, 0.02);
   border-color: var(--error-color);
 }
 
-.file-header {
+.file-header,
+.tt-file-header {
   display: flex;
   align-items: center;
   gap: 1rem;
   margin-bottom: 0.75rem;
 }
 
-.file-icon {
+.file-icon,
+.tt-file-icon {
   width: 50px;
   height: 50px;
   background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
@@ -181,12 +191,14 @@
   flex-shrink: 0;
 }
 
-.file-info {
+.file-info,
+.tt-file-info {
   flex: 1;
   min-width: 0;
 }
 
-.file-name {
+.file-name,
+.tt-file-name {
   font-weight: 600;
   color: var(--tertiary-color);
   margin-bottom: 0.25rem;
@@ -195,12 +207,14 @@
   text-overflow: ellipsis;
 }
 
-.file-size {
+.file-size,
+.tt-file-size {
   font-size: 0.85rem;
   color: var(--muted-color);
 }
 
-.file-status {
+.file-status,
+.tt-file-status {
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -209,23 +223,28 @@
   white-space: nowrap;
 }
 
-.file-status.uploading {
+.file-status.uploading,
+.tt-file-status.uploading {
   color: var(--primary-color);
 }
 
-.file-status.processing {
+.file-status.processing,
+.tt-file-status.processing {
   color: var(--primary-color);
 }
 
-.file-status.success {
+.file-status.success,
+.tt-file-status.success {
   color: var(--success-color);
 }
 
-.file-status.error {
+.file-status.error,
+.tt-file-status.error {
   color: var(--error-color);
 }
 
-.progress-bar-container {
+.progress-bar-container,
+.tt-progress-bar-container {
   width: 100%;
   height: 8px;
   background: #f0f0f0;
@@ -234,35 +253,42 @@
   margin-bottom: 0.5rem;
 }
 
-.progress-bar-fill {
+.progress-bar-fill,
+.tt-progress-bar-fill {
   height: 100%;
   background: var(--primary-color);
   transition: width 0.3s ease;
   border-radius: 4px;
 }
 
-.progress-bar-fill.success {
+.progress-bar-fill.success,
+.tt-progress-bar-fill.success {
   background: var(--success-color);
 }
 
-.progress-details {
+.progress-details,
+.tt-progress-details {
   font-size: 0.8rem;
   color: var(--muted-color);
 }
 
-.progress-details.error {
+.progress-details.error,
+.tt-progress-details.error {
   color: var(--error-color);
 }
 
-.progress-details.success {
+.progress-details.success,
+.tt-progress-details.success {
   color: var(--success-color);
 }
 
 /* ========================================
    Spinner Animation
+   Support both old and new (tt-) prefixed class names
    ======================================== */
 
-.spinner {
+.spinner,
+.tt-spinner {
   display: inline-block;
   width: 14px;
   height: 14px;

--- a/src/tt/static/js/trip_images.js
+++ b/src/tt/static/js/trip_images.js
@@ -3,9 +3,24 @@
  *
  * This module handles:
  * 1. Image picker functionality for selecting reference images in modals
- * 2. Drag-and-drop image uploads with progress tracking (Images home page)
+ * 2. Drag-and-drop image uploads with progress tracking
  *
- * Uses shared constants from Tt namespace (main.js) for DOM selectors.
+ * UPLOAD COMPONENT USAGE:
+ *
+ *   Tt.createImageUpload({
+ *     uploadZoneSelector: '#my-upload-zone',      // Required: drag-drop area
+ *     fileInputSelector: '#my-file-input',        // Required: hidden file input
+ *     progressSectionSelector: '#my-progress',    // Optional: progress container
+ *     progressCountSelector: '#my-count',         // Optional: "X of Y files" display
+ *     fileProgressListSelector: '#my-list',       // Optional: individual file progress
+ *     uploadedGridSelector: '#my-grid',           // Optional: uploaded images display
+ *     uploadedCountSelector: '#my-uploaded',      // Optional: total uploaded count
+ *     uploadEndpoint: '/custom/upload/',          // Optional: defaults to current URL
+ *     maxFiles: 10,                               // Optional: defaults to 50
+ *     onSuccess: function(result) { ... },        // Optional: per-file success callback
+ *     onError: function(error) { ... },           // Optional: per-file error callback
+ *     onComplete: function(allResults) { ... }    // Optional: all files done callback
+ *   });
  */
 
 // ============================================================================
@@ -93,463 +108,615 @@
 (function() {
     'use strict';
 
-    // Constants
-    var MAX_FILES_PER_BATCH = 50;
-    var UPLOAD_TIMEOUT_MS = 120000; // 2 minutes per file
-
-    // State management
-    var uploadQueue = [];
-    var completedCount = 0;
-    var currentUploadIndex = 0;
-    var isUploading = false;
-
-    // DOM element cache
-    var $uploadZone;
-    var $fileInput;
-    var $progressSection;
-    var $progressCount;
-    var $fileProgressList;
-    var $uploadedGrid;
-    var $uploadedCount;
-
-    // Module API
-    var TripImagesUpload = {
-        init: init
+    // Default configuration
+    var DEFAULT_CONFIG = {
+        uploadZoneSelector: null,
+        fileInputSelector: null,
+        progressSectionSelector: null,
+        progressCountSelector: null,
+        fileProgressListSelector: null,
+        uploadedGridSelector: null,
+        uploadedCountSelector: null,
+        uploadEndpoint: null,  // null = use current URL
+        maxFiles: 50,
+        onSuccess: null,  // Callback: function(results) { }
+        onError: null,    // Callback: function(error) { }
+        onComplete: null  // Callback: function(allResults) { }
     };
 
-    // Initialize the upload interface
-    function init() {
-        cacheDOMElements();
-        initDragAndDrop();
-        initFileInput();
-    }
+    // Global timeout constant
+    var UPLOAD_TIMEOUT_MS = 120000; // 2 minutes per file
 
-    // Cache DOM elements for performance
-    function cacheDOMElements() {
-        $uploadZone = $('#' + Tt.DIVID.IMAGES_UPLOAD_ZONE_ID);
-        $fileInput = $('#' + Tt.DIVID.IMAGES_FILE_INPUT_ID);
-        $progressSection = $('#' + Tt.DIVID.IMAGES_PROGRESS_SECTION_ID);
-        $progressCount = $('#' + Tt.DIVID.IMAGES_PROGRESS_COUNT_ID);
-        $fileProgressList = $('#' + Tt.DIVID.IMAGES_FILE_PROGRESS_LIST_ID);
-        $uploadedGrid = $('#' + Tt.DIVID.IMAGES_UPLOADED_GRID_ID);
-        $uploadedCount = $('#' + Tt.DIVID.IMAGES_UPLOADED_COUNT_ID);
-    }
+    /**
+     * Create a configurable image upload component
+     * @param {Object} config - Configuration object
+     * @returns {Object} Public API for the upload component
+     */
+    function createImageUpload(config) {
+        // Merge config with defaults
+        var settings = Object.assign({}, DEFAULT_CONFIG, config);
 
-    // Initialize drag-and-drop handlers
-    function initDragAndDrop() {
-        $uploadZone.on('dragover', handleDragOver);
-        $uploadZone.on('dragleave', handleDragLeave);
-        $uploadZone.on('drop', handleDrop);
-        $uploadZone.on('click', function(e) {
-            if (e.target.tagName !== 'BUTTON' && e.target.tagName !== 'INPUT') {
-                $fileInput.click();
+        // Validate required selectors
+        if (!settings.uploadZoneSelector) {
+            throw new Error('createImageUpload: uploadZoneSelector is required');
+        }
+        if (!settings.fileInputSelector) {
+            throw new Error('createImageUpload: fileInputSelector is required');
+        }
+
+        // Instance state management
+        var uploadQueue = [];
+        var completedCount = 0;
+        var currentUploadIndex = 0;
+        var isUploading = false;
+
+        // DOM element cache
+        var $uploadZone;
+        var $fileInput;
+        var $progressSection;
+        var $progressCount;
+        var $fileProgressList;
+        var $uploadedGrid;
+        var $uploadedCount;
+
+        /**
+         * Initialize the upload interface
+         */
+        function init() {
+            cacheDOMElements();
+            initDragAndDrop();
+            initFileInput();
+        }
+
+        /**
+         * Cache DOM elements for performance
+         */
+        function cacheDOMElements() {
+            $uploadZone = $(settings.uploadZoneSelector);
+            $fileInput = $(settings.fileInputSelector);
+            $progressSection = settings.progressSectionSelector ? $(settings.progressSectionSelector) : null;
+            $progressCount = settings.progressCountSelector ? $(settings.progressCountSelector) : null;
+            $fileProgressList = settings.fileProgressListSelector ? $(settings.fileProgressListSelector) : null;
+            $uploadedGrid = settings.uploadedGridSelector ? $(settings.uploadedGridSelector) : null;
+            $uploadedCount = settings.uploadedCountSelector ? $(settings.uploadedCountSelector) : null;
+
+            // Validate required elements exist
+            if ($uploadZone.length === 0) {
+                console.error('createImageUpload: Upload zone not found:', settings.uploadZoneSelector);
             }
-        });
-    }
+            if ($fileInput.length === 0) {
+                console.error('createImageUpload: File input not found:', settings.fileInputSelector);
+            }
+        }
 
-    // Initialize file input handler
-    function initFileInput() {
-        $fileInput.on('change', function(e) {
-            var files = e.target.files;
+        /**
+         * Initialize drag-and-drop handlers
+         */
+        function initDragAndDrop() {
+            $uploadZone.on('dragover', handleDragOver);
+            $uploadZone.on('dragleave', handleDragLeave);
+            $uploadZone.on('drop', handleDrop);
+            $uploadZone.on('click', function(e) {
+                if (e.target.tagName !== 'BUTTON' && e.target.tagName !== 'INPUT') {
+                    $fileInput.click();
+                }
+            });
+        }
+
+        /**
+         * Initialize file input handler
+         */
+        function initFileInput() {
+            $fileInput.on('change', function(e) {
+                var files = e.target.files;
+                if (files.length > 0) {
+                    handleFiles(files);
+                }
+                // Reset input so same files can be selected again
+                e.target.value = '';
+            });
+        }
+
+        /**
+         * Handle drag over event
+         */
+        function handleDragOver(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            $uploadZone.addClass('tt-upload-dragover');
+        }
+
+        /**
+         * Handle drag leave event
+         */
+        function handleDragLeave(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            $uploadZone.removeClass('tt-upload-dragover');
+        }
+
+        /**
+         * Handle drop event
+         */
+        function handleDrop(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            $uploadZone.removeClass('tt-upload-dragover');
+
+            var files = e.originalEvent.dataTransfer.files;
             if (files.length > 0) {
                 handleFiles(files);
             }
-            // Reset input so same files can be selected again
-            e.target.value = '';
-        });
-    }
-
-    // Handle drag over event
-    function handleDragOver(e) {
-        e.preventDefault();
-        e.stopPropagation();
-        $uploadZone.addClass('dragover');
-    }
-
-    // Handle drag leave event
-    function handleDragLeave(e) {
-        e.preventDefault();
-        e.stopPropagation();
-        $uploadZone.removeClass('dragover');
-    }
-
-    // Handle drop event
-    function handleDrop(e) {
-        e.preventDefault();
-        e.stopPropagation();
-        $uploadZone.removeClass('dragover');
-
-        var files = e.originalEvent.dataTransfer.files;
-        if (files.length > 0) {
-            handleFiles(files);
-        }
-    }
-
-    // Handle file selection
-    function handleFiles(files) {
-        var fileArray = Array.from(files);
-
-        // Validate file count
-        if (fileArray.length > MAX_FILES_PER_BATCH) {
-            alert('Too many files selected. Maximum ' + MAX_FILES_PER_BATCH + ' files allowed per batch.');
-            return;
         }
 
-        // Validate files
-        var validFiles = fileArray.filter(function(file) {
-            return validateFile(file);
-        });
+        /**
+         * Handle file selection
+         */
+        function handleFiles(files) {
+            var fileArray = Array.from(files);
 
-        if (validFiles.length === 0) {
-            alert('No valid image files selected. Please select JPG, PNG, or HEIC files under 20MB.');
-            return;
+            // Validate file count
+            if (fileArray.length > settings.maxFiles) {
+                alert('Too many files selected. Maximum ' + settings.maxFiles + ' files allowed per batch.');
+                return;
+            }
+
+            // Validate files
+            var validFiles = fileArray.filter(function(file) {
+                return validateFile(file);
+            });
+
+            if (validFiles.length === 0) {
+                alert('No valid image files selected. Please select JPG, PNG, or HEIC files under 20MB.');
+                return;
+            }
+
+            // Reset state
+            uploadQueue = validFiles.map(function(file, index) {
+                return {
+                    file: file,
+                    id: 'file-' + Date.now() + '-' + index,
+                    status: 'queued',
+                    progress: 0
+                };
+            });
+
+            completedCount = 0;
+            currentUploadIndex = 0;
+            isUploading = false;
+
+            // Show progress section if available
+            if ($progressSection && $progressSection.length > 0) {
+                $progressSection.addClass('active');
+            }
+            updateProgressCount();
+
+            // Create progress items for each file
+            if ($fileProgressList && $fileProgressList.length > 0) {
+                $fileProgressList.empty();
+                uploadQueue.forEach(function(fileItem) {
+                    createProgressItem(fileItem);
+                });
+            }
+
+            // Start sequential uploads
+            uploadNextFile();
         }
 
-        // Reset state
-        uploadQueue = validFiles.map(function(file, index) {
-            return {
-                file: file,
-                id: 'file-' + Date.now() + '-' + index,
-                status: 'queued',
-                progress: 0
-            };
-        });
+        /**
+         * Validate file
+         */
+        function validateFile(file) {
+            var maxSize = 20 * 1024 * 1024; // 20MB
+            var validTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/heic'];
 
-        completedCount = 0;
-        currentUploadIndex = 0;
-        isUploading = false;
+            if (file.size > maxSize) {
+                return false;
+            }
 
-        // Show progress section
-        $progressSection.addClass('active');
-        updateProgressCount();
+            var fileType = file.type.toLowerCase();
+            var fileName = file.name.toLowerCase();
 
-        // Create progress items for each file
-        $fileProgressList.empty();
-        uploadQueue.forEach(function(fileItem) {
-            createProgressItem(fileItem);
-        });
+            if (validTypes.includes(fileType)) {
+                return true;
+            }
 
-        // Start sequential uploads
-        uploadNextFile();
-    }
+            // Check extension for HEIC (some browsers don't set correct MIME type)
+            if (fileName.endsWith('.heic')) {
+                return true;
+            }
 
-    // Validate file
-    function validateFile(file) {
-        var maxSize = 20 * 1024 * 1024; // 20MB
-        var validTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/heic'];
-
-        if (file.size > maxSize) {
             return false;
         }
 
-        var fileType = file.type.toLowerCase();
-        var fileName = file.name.toLowerCase();
+        /**
+         * Create progress item HTML
+         */
+        function createProgressItem(fileItem) {
+            var $progressItem = $('<div></div>')
+                .addClass('tt-file-progress-item')
+                .attr('id', fileItem.id);
 
-        if (validTypes.includes(fileType)) {
-            return true;
-        }
+            var fileSize = formatFileSize(fileItem.file.size);
 
-        // Check extension for HEIC (some browsers don't set correct MIME type)
-        if (fileName.endsWith('.heic')) {
-            return true;
-        }
-
-        return false;
-    }
-
-    // Create progress item HTML
-    function createProgressItem(fileItem) {
-        var $progressItem = $('<div></div>')
-            .addClass('file-progress-item')
-            .attr('id', fileItem.id);
-
-        var fileSize = formatFileSize(fileItem.file.size);
-
-        var html =
-            '<div class="file-header">' +
-                '<div class="file-icon"></div>' +
-                '<div class="file-info">' +
-                    '<div class="file-name">' + escapeHtml(fileItem.file.name) + '</div>' +
-                    '<div class="file-size">' + fileSize + '</div>' +
+            var html =
+                '<div class="tt-file-header">' +
+                    '<div class="tt-file-icon"></div>' +
+                    '<div class="tt-file-info">' +
+                        '<div class="tt-file-name">' + escapeHtml(fileItem.file.name) + '</div>' +
+                        '<div class="tt-file-size">' + fileSize + '</div>' +
+                    '</div>' +
+                    '<div class="tt-file-status" data-status-target>' +
+                        'Queued' +
+                    '</div>' +
                 '</div>' +
-                '<div class="file-status" data-status-target>' +
-                    'Queued' +
+                '<div class="tt-progress-bar-container" style="display: none;">' +
+                    '<div class="tt-progress-bar-fill" data-progress-bar></div>' +
                 '</div>' +
-            '</div>' +
-            '<div class="progress-bar-container" style="display: none;">' +
-                '<div class="progress-bar-fill" data-progress-bar></div>' +
-            '</div>' +
-            '<div class="progress-details" data-details-target></div>';
+                '<div class="tt-progress-details" data-details-target></div>';
 
-        $progressItem.html(html);
-        $fileProgressList.append($progressItem);
-    }
-
-    // Upload next file in queue (sequential processing)
-    function uploadNextFile() {
-        // Check if all files are processed
-        if (currentUploadIndex >= uploadQueue.length) {
-            isUploading = false;
-            return;
+            $progressItem.html(html);
+            $fileProgressList.append($progressItem);
         }
 
-        // Prevent concurrent uploads
-        if (isUploading) {
-            return;
-        }
+        /**
+         * Upload next file in queue (sequential processing)
+         */
+        function uploadNextFile() {
+            // Check if all files are processed
+            if (currentUploadIndex >= uploadQueue.length) {
+                isUploading = false;
 
-        isUploading = true;
-        var fileItem = uploadQueue[currentUploadIndex];
-
-        // Upload single file
-        uploadSingleFile(fileItem, currentUploadIndex);
-    }
-
-    // Upload a single file
-    function uploadSingleFile(fileItem, index) {
-        var formData = new FormData();
-        formData.append('files', fileItem.file);
-
-        // Mark as uploading
-        updateFileStatus(fileItem.id, 'uploading', 'Uploading...', 0);
-
-        // Track XHR for timeout handling
-        var timeoutId = setTimeout(function() {
-            console.error('Upload timeout for file:', fileItem.file.name);
-            handleSingleFileError(fileItem, 'Upload timed out after ' + (UPLOAD_TIMEOUT_MS / 1000) + ' seconds');
-        }, UPLOAD_TIMEOUT_MS);
-
-        // Use jQuery AJAX for file upload
-        $.ajax({
-            url: window.location.pathname,
-            type: 'POST',
-            data: formData,
-            processData: false,
-            contentType: false,
-            headers: {
-                'X-Requested-With': 'XMLHttpRequest'
-            },
-            timeout: UPLOAD_TIMEOUT_MS,
-            xhr: function() {
-                var xhr = new window.XMLHttpRequest();
-                // Upload progress tracking
-                xhr.upload.addEventListener('progress', function(e) {
-                    if (e.lengthComputable) {
-                        var percentComplete = Math.round((e.loaded / e.total) * 100);
-                        updateFileStatus(fileItem.id, 'uploading', 'Uploading...', percentComplete);
-                    }
-                }, false);
-                return xhr;
-            },
-            success: function(data) {
-                clearTimeout(timeoutId);
-                handleSingleFileResponse(fileItem, data, index);
-            },
-            error: function(xhr, textStatus, errorThrown) {
-                clearTimeout(timeoutId);
-                var errorMsg = buildErrorMessage(xhr, textStatus, errorThrown);
-                handleSingleFileError(fileItem, errorMsg);
-            }
-        });
-    }
-
-    // Handle single file upload response
-    function handleSingleFileResponse(fileItem, data, index) {
-        if (!data.files || !Array.isArray(data.files) || data.files.length === 0) {
-            console.error('Invalid response format for file:', fileItem.file.name, data);
-            handleSingleFileError(fileItem, 'Server returned invalid response');
-            return;
-        }
-
-        // Get the first (and only) file result
-        var fileResult = data.files[0];
-
-        if (fileResult.status === 'success') {
-            completedCount++;
-            var details = buildSuccessDetails(fileResult);
-            updateFileStatus(fileItem.id, 'success', 'Complete', 100, details);
-
-            // Add to grid
-            addImageToGrid(fileResult);
-        } else {
-            completedCount++;
-            var errorMsg = fileResult.error_message || 'Upload failed';
-            updateFileStatus(fileItem.id, 'error', 'Failed', null, errorMsg);
-        }
-
-        updateProgressCount();
-        updateUploadedCount();
-
-        // Move to next file
-        currentUploadIndex++;
-        isUploading = false;
-        uploadNextFile();
-    }
-
-    // Handle single file upload error
-    function handleSingleFileError(fileItem, errorMsg) {
-        console.error('Upload error for file:', fileItem.file.name, errorMsg);
-
-        completedCount++;
-        updateFileStatus(fileItem.id, 'error', 'Failed', null, errorMsg);
-        updateProgressCount();
-
-        // Move to next file even after error
-        currentUploadIndex++;
-        isUploading = false;
-        uploadNextFile();
-    }
-
-    // Build error message from AJAX error
-    function buildErrorMessage(xhr, textStatus, errorThrown) {
-        if (textStatus === 'timeout') {
-            return 'Upload timed out - file may be too large or connection too slow';
-        }
-
-        if (xhr.status === 413) {
-            return 'File too large for server (413 error)';
-        }
-
-        if (xhr.status === 0) {
-            return 'Network error - please check your connection';
-        }
-
-        if (xhr.status >= 500) {
-            return 'Server error (' + xhr.status + ') - please try again';
-        }
-
-        if (xhr.status >= 400) {
-            // Try to parse error message from response
-            try {
-                var response = JSON.parse(xhr.responseText);
-                if (response.error) {
-                    return response.error;
+                // Call onComplete callback if provided
+                if (settings.onComplete && typeof settings.onComplete === 'function') {
+                    var allResults = uploadQueue.map(function(item) {
+                        return {
+                            file: item.file,
+                            status: item.status,
+                            result: item.result
+                        };
+                    });
+                    settings.onComplete(allResults);
                 }
-            } catch (e) {
-                // Ignore JSON parse errors
-            }
-            return 'Upload failed (' + xhr.status + ')';
-        }
-
-        return errorThrown || 'Upload failed - unknown error';
-    }
-
-    // Update file status
-    function updateFileStatus(fileId, status, statusText, progress, details) {
-        var $progressItem = $('#' + fileId);
-        if ($progressItem.length === 0) return;
-
-        // Update item class
-        $progressItem.attr('class', 'file-progress-item ' + status);
-
-        // Update status badge
-        var $statusTarget = $progressItem.find('[data-status-target]');
-        if ($statusTarget.length > 0) {
-            $statusTarget.attr('class', 'file-status ' + status);
-
-            var iconHtml = '';
-            if (status === 'uploading' || status === 'processing') {
-                iconHtml = '<span class="spinner"></span>';
-            } else if (status === 'success') {
-                iconHtml = '<span style="color: var(--success-color);">&#10003;</span>';
-            } else if (status === 'error') {
-                iconHtml = '<span style="color: var(--error-color);">!</span>';
+                return;
             }
 
-            $statusTarget.html(iconHtml + ' ' + statusText);
+            // Prevent concurrent uploads
+            if (isUploading) {
+                return;
+            }
+
+            isUploading = true;
+            var fileItem = uploadQueue[currentUploadIndex];
+
+            // Upload single file
+            uploadSingleFile(fileItem, currentUploadIndex);
         }
 
-        // Update progress bar
-        var $progressBarContainer = $progressItem.find('.progress-bar-container');
-        var $progressBar = $progressItem.find('[data-progress-bar]');
+        /**
+         * Upload a single file
+         */
+        function uploadSingleFile(fileItem, index) {
+            var formData = new FormData();
+            formData.append('files', fileItem.file);
 
-        if (progress !== null && $progressBarContainer.length > 0 && $progressBar.length > 0) {
-            $progressBarContainer.show();
-            $progressBar.css('width', progress + '%');
+            // Mark as uploading
+            updateFileStatus(fileItem.id, 'uploading', 'Uploading...', 0);
 
-            if (status === 'success') {
-                $progressBar.addClass('success');
+            // Track XHR for timeout handling
+            var timeoutId = setTimeout(function() {
+                console.error('Upload timeout for file:', fileItem.file.name);
+                handleSingleFileError(fileItem, 'Upload timed out after ' + (UPLOAD_TIMEOUT_MS / 1000) + ' seconds');
+            }, UPLOAD_TIMEOUT_MS);
+
+            // Determine upload endpoint
+            var uploadUrl = settings.uploadEndpoint || window.location.pathname;
+
+            // Use jQuery AJAX for file upload
+            $.ajax({
+                url: uploadUrl,
+                type: 'POST',
+                data: formData,
+                processData: false,
+                contentType: false,
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest'
+                },
+                timeout: UPLOAD_TIMEOUT_MS,
+                xhr: function() {
+                    var xhr = new window.XMLHttpRequest();
+                    // Upload progress tracking
+                    xhr.upload.addEventListener('progress', function(e) {
+                        if (e.lengthComputable) {
+                            var percentComplete = Math.round((e.loaded / e.total) * 100);
+                            updateFileStatus(fileItem.id, 'uploading', 'Uploading...', percentComplete);
+                        }
+                    }, false);
+                    return xhr;
+                },
+                success: function(data) {
+                    clearTimeout(timeoutId);
+                    handleSingleFileResponse(fileItem, data, index);
+                },
+                error: function(xhr, textStatus, errorThrown) {
+                    clearTimeout(timeoutId);
+                    var errorMsg = buildErrorMessage(xhr, textStatus, errorThrown);
+                    handleSingleFileError(fileItem, errorMsg);
+                }
+            });
+        }
+
+        /**
+         * Handle single file upload response
+         */
+        function handleSingleFileResponse(fileItem, data, index) {
+            if (!data.files || !Array.isArray(data.files) || data.files.length === 0) {
+                console.error('Invalid response format for file:', fileItem.file.name, data);
+                handleSingleFileError(fileItem, 'Server returned invalid response');
+                return;
+            }
+
+            // Get the first (and only) file result
+            var fileResult = data.files[0];
+
+            if (fileResult.status === 'success') {
+                completedCount++;
+                var details = buildSuccessDetails(fileResult);
+                updateFileStatus(fileItem.id, 'success', 'Complete', 100, details);
+
+                // Store result in queue item
+                uploadQueue[index].status = 'success';
+                uploadQueue[index].result = fileResult;
+
+                // Add to grid
+                addImageToGrid(fileResult);
+
+                // Call onSuccess callback if provided
+                if (settings.onSuccess && typeof settings.onSuccess === 'function') {
+                    settings.onSuccess(fileResult);
+                }
+            } else {
+                completedCount++;
+                var errorMsg = fileResult.error_message || 'Upload failed';
+                updateFileStatus(fileItem.id, 'error', 'Failed', null, errorMsg);
+
+                // Store error in queue item
+                uploadQueue[index].status = 'error';
+                uploadQueue[index].error = errorMsg;
+
+                // Call onError callback if provided
+                if (settings.onError && typeof settings.onError === 'function') {
+                    settings.onError({
+                        file: fileItem.file,
+                        error: errorMsg
+                    });
+                }
+            }
+
+            updateProgressCount();
+            updateUploadedCount();
+
+            // Move to next file
+            currentUploadIndex++;
+            isUploading = false;
+            uploadNextFile();
+        }
+
+        /**
+         * Handle single file upload error
+         */
+        function handleSingleFileError(fileItem, errorMsg) {
+            console.error('Upload error for file:', fileItem.file.name, errorMsg);
+
+            completedCount++;
+            updateFileStatus(fileItem.id, 'error', 'Failed', null, errorMsg);
+            updateProgressCount();
+
+            // Store error in queue item
+            var itemIndex = uploadQueue.findIndex(function(item) {
+                return item.id === fileItem.id;
+            });
+            if (itemIndex >= 0) {
+                uploadQueue[itemIndex].status = 'error';
+                uploadQueue[itemIndex].error = errorMsg;
+            }
+
+            // Call onError callback if provided
+            if (settings.onError && typeof settings.onError === 'function') {
+                settings.onError({
+                    file: fileItem.file,
+                    error: errorMsg
+                });
+            }
+
+            // Move to next file even after error
+            currentUploadIndex++;
+            isUploading = false;
+            uploadNextFile();
+        }
+
+        /**
+         * Build error message from AJAX error
+         */
+        function buildErrorMessage(xhr, textStatus, errorThrown) {
+            if (textStatus === 'timeout') {
+                return 'Upload timed out - file may be too large or connection too slow';
+            }
+
+            if (xhr.status === 413) {
+                return 'File too large for server (413 error)';
+            }
+
+            if (xhr.status === 0) {
+                return 'Network error - please check your connection';
+            }
+
+            if (xhr.status >= 500) {
+                return 'Server error (' + xhr.status + ') - please try again';
+            }
+
+            if (xhr.status >= 400) {
+                // Try to parse error message from response
+                try {
+                    var response = JSON.parse(xhr.responseText);
+                    if (response.error) {
+                        return response.error;
+                    }
+                } catch (e) {
+                    // Ignore JSON parse errors
+                }
+                return 'Upload failed (' + xhr.status + ')';
+            }
+
+            return errorThrown || 'Upload failed - unknown error';
+        }
+
+        /**
+         * Update file status
+         */
+        function updateFileStatus(fileId, status, statusText, progress, details) {
+            var $progressItem = $('#' + fileId);
+            if ($progressItem.length === 0) return;
+
+            // Update item class
+            $progressItem.attr('class', 'tt-file-progress-item ' + status);
+
+            // Update status badge
+            var $statusTarget = $progressItem.find('[data-status-target]');
+            if ($statusTarget.length > 0) {
+                $statusTarget.attr('class', 'tt-file-status ' + status);
+
+                var iconHtml = '';
+                if (status === 'uploading' || status === 'processing') {
+                    iconHtml = '<span class="tt-spinner"></span>';
+                } else if (status === 'success') {
+                    iconHtml = '<span style="color: var(--success-color);">&#10003;</span>';
+                } else if (status === 'error') {
+                    iconHtml = '<span style="color: var(--error-color);">!</span>';
+                }
+
+                $statusTarget.html(iconHtml + ' ' + statusText);
+            }
+
+            // Update progress bar
+            var $progressBarContainer = $progressItem.find('.tt-progress-bar-container');
+            var $progressBar = $progressItem.find('[data-progress-bar]');
+
+            if (progress !== null && $progressBarContainer.length > 0 && $progressBar.length > 0) {
+                $progressBarContainer.show();
+                $progressBar.css('width', progress + '%');
+
+                if (status === 'success') {
+                    $progressBar.addClass('success');
+                }
+            }
+
+            // Update details
+            var $detailsTarget = $progressItem.find('[data-details-target]');
+            if ($detailsTarget.length > 0 && details) {
+                $detailsTarget.text(details);
+                $detailsTarget.attr('class', 'tt-progress-details ' + status);
             }
         }
 
-        // Update details
-        var $detailsTarget = $progressItem.find('[data-details-target]');
-        if ($detailsTarget.length > 0 && details) {
-            $detailsTarget.text(details);
-            $detailsTarget.attr('class', 'progress-details ' + status);
-        }
-    }
+        /**
+         * Build success details text
+         */
+        function buildSuccessDetails(fileResult) {
+            var parts = [];
 
-    // Build success details text
-    function buildSuccessDetails(fileResult) {
-        var parts = [];
+            if (fileResult.metadata) {
+                var meta = fileResult.metadata;
 
-        if (fileResult.metadata) {
-            var meta = fileResult.metadata;
+                if (meta.datetime_utc) {
+                    var date = new Date(meta.datetime_utc);
+                    parts.push('Date: ' + date.toLocaleString());
+                }
 
-            if (meta.datetime_utc) {
-                var date = new Date(meta.datetime_utc);
-                parts.push('Date: ' + date.toLocaleString());
+                if (meta.latitude && meta.longitude) {
+                    parts.push('Location: ' + meta.latitude.toFixed(4) + ', ' + meta.longitude.toFixed(4));
+                }
+
+                if (parts.length > 0) {
+                    return 'EXIF extracted - ' + parts.join(' - ');
+                }
             }
 
-            if (meta.latitude && meta.longitude) {
-                parts.push('Location: ' + meta.latitude.toFixed(4) + ', ' + meta.longitude.toFixed(4));
+            return 'Upload complete';
+        }
+
+        /**
+         * Add image to grid
+         */
+        function addImageToGrid(fileResult) {
+            if (!$uploadedGrid || $uploadedGrid.length === 0) return;
+
+            // Remove empty state if present
+            var $emptyState = $uploadedGrid.find('.empty-state');
+            if ($emptyState.length > 0) {
+                $emptyState.remove();
             }
 
-            if (parts.length > 0) {
-                return 'EXIF extracted - ' + parts.join(' - ');
+            // Insert server-rendered HTML
+            if (fileResult.html) {
+                $uploadedGrid.prepend(fileResult.html);
             }
         }
 
-        return 'Upload complete';
-    }
-
-    // Add image to grid
-    function addImageToGrid(fileResult) {
-        // Remove empty state if present
-        var $emptyState = $uploadedGrid.find('.empty-state');
-        if ($emptyState.length > 0) {
-            $emptyState.remove();
+        /**
+         * Update progress count
+         */
+        function updateProgressCount() {
+            if (!$progressCount || $progressCount.length === 0) return;
+            $progressCount.text(completedCount + ' of ' + uploadQueue.length + ' files');
         }
 
-        // Insert server-rendered HTML
-        if (fileResult.html) {
-            $uploadedGrid.prepend(fileResult.html);
+        /**
+         * Update uploaded count
+         */
+        function updateUploadedCount() {
+            if (!$uploadedCount || $uploadedCount.length === 0) return;
+
+            var currentCount = parseInt($uploadedCount.text()) || 0;
+            var successCount = uploadQueue.filter(function(item) {
+                var $elem = $('#' + item.id);
+                return $elem.length > 0 && $elem.hasClass('success');
+            }).length;
+
+            $uploadedCount.text(currentCount + successCount);
         }
-    }
 
-    // Update progress count
-    function updateProgressCount() {
-        $progressCount.text(completedCount + ' of ' + uploadQueue.length + ' files');
-    }
+        /**
+         * Format file size
+         */
+        function formatFileSize(bytes) {
+            if (bytes < 1024) return bytes + ' B';
+            if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+            return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+        }
 
-    // Update uploaded count
-    function updateUploadedCount() {
-        var currentCount = parseInt($uploadedCount.text()) || 0;
-        var successCount = uploadQueue.filter(function(item) {
-            var $elem = $('#' + item.id);
-            return $elem.length > 0 && $elem.hasClass('success');
-        }).length;
+        /**
+         * Escape HTML to prevent XSS
+         */
+        function escapeHtml(text) {
+            var div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
 
-        $uploadedCount.text(currentCount + successCount);
-    }
+        // Initialize on creation
+        init();
 
-    // Format file size
-    function formatFileSize(bytes) {
-        if (bytes < 1024) return bytes + ' B';
-        if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
-        return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
-    }
-
-    // Escape HTML to prevent XSS
-    function escapeHtml(text) {
-        var div = document.createElement('div');
-        div.textContent = text;
-        return div.innerHTML;
+        // Return public API
+        return {
+            // No public methods needed currently, but we could add:
+            // reset: function() { ... },
+            // addFiles: function(files) { handleFiles(files); }
+        };
     }
 
     // Export to Tt namespace
     window.Tt = window.Tt || {};
-    window.Tt.tripImagesUpload = TripImagesUpload;
+    window.Tt.createImageUpload = createImageUpload;
 
 })();


### PR DESCRIPTION
## Pull Request: Added image upload options throughout app

### Issue Link
Closes #56

---

## Category
- [x] **Feature** (New functionality)
- [ ] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ] **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary
- **Refactored image upload into reusable components**: Created configurable JavaScript factory `Tt.createImageUpload()` and abstract `EntityImageUploadView` class
- **Migrated existing image upload page**: Updated `ImagesHomeView` to use new reusable components
- **Added Trip reference image upload**: Single-image modal upload that automatically sets uploaded image as Trip's reference image
- **Added Journal reference image upload**: Single-image modal upload that automatically sets uploaded image as Journal's reference image  
- **Added JournalEntry multi-image upload**: Multi-image modal upload for adding images during journal entry editing
- **Consistent upload button placement**: Added upload buttons next to "Filter by date" in image pickers and next to "Images" title in journal entry editor

---

## How to Test
1. **Trip reference image upload**: Go to any trip → Images tab → click reference image → click "Upload" button → test single image upload and auto-set
2. **Journal reference image upload**: Go to any journal → click reference image → click "Upload" button → test single image upload and auto-set  
3. **Journal entry multi-image upload**: Edit any journal entry → right panel "Images" section → click "Upload" button → test multi-image upload
4. **Existing image upload page**: Go to any trip → Images tab → verify existing bulk upload still works with new components
5. **Test all upload modes**: Single-image (auto page refresh), multi-image (manual DONE button refresh)

---

## Checklist
- [x] Code follows the project's style guidelines.
- [x] Unit tests added or updated if necessary.
- [x] All tests pass (`./manage.py test`).
- [ ] Docs updated if applicable.
- [x] No breaking changes introduced.

---

## Related PRs

---

## Screenshots (if applicable)

---

## Additional Notes
This implements the complete 4-phase refactoring outlined in Issue #56:
- Phase 1: Reusable components (JavaScript factory pattern + Django abstract view)
- Phase 2: Migration of existing upload page  
- Phase 3: Trip and Journal reference image upload modals (single-image mode)
- Phase 4: JournalEntry multi-image upload modal

All upload functionality now uses the same underlying components but with different configurations (single vs multi-image, auto-refresh vs manual refresh).

---

### **Ready for Review?**
- [x] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**
@cassandra
