### PR TITLE
Added click and image picker for JournalEntry reference images.

### DIFF
--- a/src/tt/apps/images/templates/images/components/image_picker_card.html
+++ b/src/tt/apps/images/templates/images/components/image_picker_card.html
@@ -10,13 +10,13 @@ Context variables:
      data-{{ DIVID.IMAGE_PICKER_UUID_ATTR }}="{{ image.uuid }}"
      data-{{ DIVID.IMAGE_PICKER_THUMBNAIL_URL_ATTR }}="{{ image.thumbnail_image.url }}"
      data-{{ DIVID.IMAGE_PICKER_CAPTION_ATTR }}="{{ image.caption|default:'Untitled' }}"
-     style="cursor: pointer; border: 2px solid transparent; border-radius: 8px; overflow: hidden; transition: border-color 0.2s;"
-     onclick="selectReferenceImage(this)">
-  <div style="width: 100%; height: 150px; overflow: hidden;">
+     tabindex="0"
+     role="button"
+     aria-label="Select {{ image.caption|default:'untitled image' }}">
+  <div class="image-picker-card-image">
     <img src="{{ image.thumbnail_image.url }}"
          alt="{{ image.caption }}"
-         class="w-100 h-100"
-         style="object-fit: cover;">
+         class="w-100 h-100">
   </div>
   <div class="p-2 bg-light">
     <small class="font-weight-bold d-block text-truncate">

--- a/src/tt/apps/journal/templates/journal/components/journal_entry_image_picker.html
+++ b/src/tt/apps/journal/templates/journal/components/journal_entry_image_picker.html
@@ -5,7 +5,7 @@
 <div class="{{ DIVID.JOURNAL_IMAGE_PANEL_HEADER_CLASS }}">
   <div class="d-flex justify-content-between align-items-center mb-2">
     <h5 class="mb-0">Images</h5>
-    <a href="{% url 'journal_entry_image_upload' entry_uuid=entry.uuid %}"
+    <a href="{% url 'journal_entry_multi_image_upload' entry_uuid=entry.uuid %}"
        class="btn btn-sm btn-outline-primary"
        data-async="modal">
       {% icon "upload" size="sm" css_class="tt-icon-left" %}

--- a/src/tt/apps/journal/templates/journal/modals/journal_entry_image_upload.html
+++ b/src/tt/apps/journal/templates/journal/modals/journal_entry_image_upload.html
@@ -1,20 +1,4 @@
 {% extends "images/modals/entity_image_upload.html" %}
 
 {% block modal_dialog_id %}journal-entry-image-upload-modal{% endblock %}
-{% block title_text %}Upload Images{% endblock %}
-
-{% comment %}
-Multi-image upload modal for Journal Entry context.
-Overrides the DONE button to refresh the page when closed,
-so newly uploaded images appear in the image picker gallery.
-{% endcomment %}
-
-{% block action_right %}
-<button type="button"
-        class="btn btn-primary"
-        onclick="location.reload();">
-  {% load icons %}
-  {% icon "save" size="sm" css_class="tt-icon-left" %}
-  DONE
-</button>
-{% endblock %}
+{% block title_text %}Upload Journal Entry Image{% endblock %}

--- a/src/tt/apps/journal/templates/journal/modals/journal_entry_multi_image_upload.html
+++ b/src/tt/apps/journal/templates/journal/modals/journal_entry_multi_image_upload.html
@@ -1,0 +1,20 @@
+{% extends "images/modals/entity_image_upload.html" %}
+
+{% block modal_dialog_id %}journal-entry-multi-image-upload-modal{% endblock %}
+{% block title_text %}Upload Images{% endblock %}
+
+{% comment %}
+Multi-image upload modal for Journal Entry sidebar.
+Overrides the DONE button to refresh the page when closed,
+so newly uploaded images appear in the image picker gallery.
+{% endcomment %}
+
+{% block action_right %}
+<button type="button"
+        class="btn btn-primary"
+        onclick="location.reload();">
+  {% load icons %}
+  {% icon "save" size="sm" css_class="tt-icon-left" %}
+  DONE
+</button>
+{% endblock %}

--- a/src/tt/apps/journal/templates/journal/modals/journal_entry_reference_image_picker.html
+++ b/src/tt/apps/journal/templates/journal/modals/journal_entry_reference_image_picker.html
@@ -1,0 +1,4 @@
+{% extends "images/modals/entity_image_picker.html" %}
+
+{% block modal_dialog_id %}journal-entry-reference-image-picker-modal{% endblock %}
+{% block title_text %}Select Reference Image{% endblock %}

--- a/src/tt/apps/journal/templates/journal/pages/journal_entry.html
+++ b/src/tt/apps/journal/templates/journal/pages/journal_entry.html
@@ -36,27 +36,39 @@
         <!-- Left column: Reference Image (hidden on small screens) -->
         <div class="col-md-3 d-none d-md-block">
           <div class="form-group">
-            <div class="{{ DIVID.JOURNAL_REFERENCE_IMAGE_CONTAINER_CLASS }}"
-                 data-{{ DIVID.JOURNAL_REFERENCE_IMAGE_UUID_ATTR }}="{% if entry.reference_image %}{{ entry.reference_image.uuid }}{% endif %}">
+            {% if trip_page.request_member.can_edit_trip %}
+            {# Clickable wrapper for opening reference image picker modal #}
+            <a href="{% url 'journal_entry_reference_image_picker' entry_uuid=entry.uuid %}"
+               data-async="modal"
+               title="Click to change reference image"
+               class="d-block"
+               role="button"
+               aria-label="Change reference image">
+            {% endif %}
+              <div class="{{ DIVID.JOURNAL_REFERENCE_IMAGE_CONTAINER_CLASS }}"
+                   data-{{ DIVID.JOURNAL_REFERENCE_IMAGE_UUID_ATTR }}="{% if entry.reference_image %}{{ entry.reference_image.uuid }}{% endif %}">
 
-              <!-- Placeholder state: Camera icon (drop zone) - shown when no reference image -->
-              <div class="{{ DIVID.JOURNAL_REFERENCE_IMAGE_PLACEHOLDER_CLASS }}{% if entry.reference_image %} d-none{% endif %}">
-                {% icon "camera" size="lg" %}
-                <span class="journal-reference-drop-hint">Drop reference image</span>
-              </div>
+                <!-- Placeholder state: Camera icon (drop zone) - shown when no reference image -->
+                <div class="{{ DIVID.JOURNAL_REFERENCE_IMAGE_PLACEHOLDER_CLASS }}{% if entry.reference_image %} d-none{% endif %}">
+                  {% icon "camera" size="lg" %}
+                  <span class="journal-reference-drop-hint">Drop reference image</span>
+                </div>
 
-              <!-- Preview state: Show thumbnail + clear button - shown when reference image set -->
-              <div class="{{ DIVID.JOURNAL_REFERENCE_IMAGE_PREVIEW_CLASS }}{% if not entry.reference_image %} d-none{% endif %}">
-                <img src="{% if entry.reference_image %}{{ entry.reference_image.thumbnail_image.url }}{% endif %}"
-                     alt="{% if entry.reference_image %}{{ entry.reference_image.caption|default:'Reference' }}{% endif %}"
-                     class="{{ DIVID.JOURNAL_REFERENCE_IMAGE_THUMBNAIL_CLASS }}"
-                     draggable="true"
-                     data-{{ DIVID.JOURNAL_INSPECT_URL_ATTR }}="{% if entry.reference_image %}{% url 'images_image_inspect' image_uuid=entry.reference_image.uuid %}?trip_uuid={{ trip.uuid }}{% endif %}">
-                <button type="button"
-                        class="{{ DIVID.JOURNAL_REFERENCE_IMAGE_CLEAR_CLASS }}"
-                        title="Clear reference image">&times;</button>
+                <!-- Preview state: Show thumbnail + clear button - shown when reference image set -->
+                <div class="{{ DIVID.JOURNAL_REFERENCE_IMAGE_PREVIEW_CLASS }}{% if not entry.reference_image %} d-none{% endif %}">
+                  <img src="{% if entry.reference_image %}{{ entry.reference_image.thumbnail_image.url }}{% endif %}"
+                       alt="{% if entry.reference_image %}{{ entry.reference_image.caption|default:'Reference' }}{% endif %}"
+                       class="{{ DIVID.JOURNAL_REFERENCE_IMAGE_THUMBNAIL_CLASS }}"
+                       draggable="true"
+                       data-{{ DIVID.JOURNAL_INSPECT_URL_ATTR }}="{% if entry.reference_image %}{% url 'images_image_inspect' image_uuid=entry.reference_image.uuid %}?trip_uuid={{ trip.uuid }}{% endif %}">
+                  <button type="button"
+                          class="{{ DIVID.JOURNAL_REFERENCE_IMAGE_CLEAR_CLASS }}"
+                          title="Clear reference image">&times;</button>
+                </div>
               </div>
-            </div>
+            {% if trip_page.request_member.can_edit_trip %}
+            </a>
+            {% endif %}
           </div>
         </div>
 

--- a/src/tt/apps/journal/urls.py
+++ b/src/tt/apps/journal/urls.py
@@ -84,9 +84,19 @@ urlpatterns = [
         name='journal_entry_images'
     ),
     path(
-        'entry/<uuid:entry_uuid>/upload-images/',
+        'entry/<uuid:entry_uuid>/reference-image-picker/',
+        views.JournalEntryReferenceImagePickerView.as_view(),
+        name='journal_entry_reference_image_picker'
+    ),
+    path(
+        'entry/<uuid:entry_uuid>/upload-image/',
         views.JournalEntryImageUploadView.as_view(),
         name='journal_entry_image_upload'
+    ),
+    path(
+        'entry/<uuid:entry_uuid>/upload-images-multi/',
+        views.JournalEntryMultiImageUploadView.as_view(),
+        name='journal_entry_multi_image_upload'
     ),
     path(
         'entry/editor-help',

--- a/src/tt/static/css/trip_images.css
+++ b/src/tt/static/css/trip_images.css
@@ -4,6 +4,39 @@
  */
 
 /* ========================================
+   Image Picker Components
+   ======================================== */
+
+.image-picker-card {
+  cursor: pointer;
+  border: 2px solid transparent;
+  border-radius: 8px;
+  overflow: hidden;
+  transition: border-color 0.2s;
+}
+
+.image-picker-card:hover,
+.image-picker-card:focus {
+  outline: none;
+  border-color: #007bff;
+}
+
+.image-picker-card:focus {
+  outline: 2px solid #007bff;
+  outline-offset: 2px;
+}
+
+.image-picker-card-image {
+  width: 100%;
+  height: 150px;
+  overflow: hidden;
+}
+
+.image-picker-card-image img {
+  object-fit: cover;
+}
+
+/* ========================================
    Container and Layout
    ======================================== */
 

--- a/src/tt/static/js/trip_images.js
+++ b/src/tt/static/js/trip_images.js
@@ -40,10 +40,27 @@
 
     window.Tt.tripImages = TtTripImages;
 
-    // Global function for onclick handlers in templates
+    // Global function for onclick handlers in templates (legacy)
     window.selectReferenceImage = function(clickedElement) {
         _selectReferenceImage(clickedElement);
     };
+
+    // Initialize delegated event handlers for image picker cards
+    $(document).ready(function() {
+        // Delegated click handler for image picker cards
+        $('body').on('click', '.' + Tt.DIVID.IMAGE_PICKER_CARD_CLASS, function(e) {
+            e.preventDefault();
+            _selectReferenceImage(this);
+        });
+
+        // Delegated keyboard handler for image picker cards (Enter/Space)
+        $('body').on('keydown', '.' + Tt.DIVID.IMAGE_PICKER_CARD_CLASS, function(e) {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                _selectReferenceImage(this);
+            }
+        });
+    });
 
     function _selectReferenceImage(clickedElement) {
         var $card = $(clickedElement).closest(Tt.IMAGE_PICKER_CARD_SELECTOR);


### PR DESCRIPTION
## Pull Request: Added click and image picker for JournalEntry reference images.

### Issue Link
Closes #72

---

## Category
- [x] **Feature** (New functionality)
- [ ] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ] **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary
- **Added `JournalEntryReferenceImagePickerView`**: Extends `EntityImagePickerView` to provide click-to-open-modal functionality for JournalEntry reference images
- **Added `JournalEntryImageUploadView`**: Single-image upload that automatically sets uploaded image as entry's reference image  
- **Renamed existing multi-image upload**: `JournalEntryImageUploadView` → `JournalEntryMultiImageUploadView` for clarity
- **Updated templates**: Added clickable wrapper around reference image with permission gating
- **Fixed coding standards violations**: Removed inline JavaScript/CSS, added accessibility attributes
- **Enhanced keyboard navigation**: Added focus indicators and Enter/Space key support for image picker cards

---

## How to Test
1. **JournalEntry reference image click**: Edit any journal entry → click reference image placeholder → verify modal opens with image picker
2. **Permission gating**: Verify only editors can click to change reference image (viewers see display-only)
3. **Image selection**: Select an image in modal → click SET → verify reference image updates and modal closes
4. **Preserved functionality**: Verify drag/drop, clear button, and double-click inspector still work
5. **Accessibility**: Test keyboard navigation (Tab to cards, Enter/Space to select)
6. **Multi-image upload**: Use sidebar "Upload" button → verify multi-image upload still works

---

## Checklist
- [x] Code follows the project's style guidelines.
- [x] Unit tests added or updated if necessary.
- [x] All tests pass (`./manage.py test`).
- [ ] Docs updated if applicable.
- [x] No breaking changes introduced.

---

## Related PRs

---

## Screenshots (if applicable)

---

## Additional Notes
This implements consistent UX behavior across all reference image contexts:
- **Trip reference image**: Click opens picker ✓
- **Journal reference image**: Click opens picker ✓  
- **JournalEntry reference image**: Click opens picker ✓ (NEW)

The implementation preserves all existing functionality while adding the missing click behavior. All code standards violations identified during review were addressed, including removal of inline JavaScript/CSS and addition of proper accessibility attributes.

---

### **Ready for Review?**
- [x] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**
@cassandra
