### PR TITLE
Dashboard Trips Ownership Categorization

### DIFF
--- a/src/tt/apps/dashboard/templates/dashboard/pages/dashboard.html
+++ b/src/tt/apps/dashboard/templates/dashboard/pages/dashboard.html
@@ -31,20 +31,31 @@
 
 {% block main_content %}
 <div class="m-3">
+  <!-- Your Upcoming Trips Section -->
   <section class="mb-4">
     <div class="d-flex justify-content-between align-items-center mb-3">
-      <h2 class="h3 mb-0">Upcoming Trips</h2>
+      <h2 class="h3 mb-0">Your Upcoming Trips</h2>
       <a href="{% url 'trips_create' %}" class="btn btn-primary" data-async="modal">+ Add New Trip</a>
     </div>
-  
-    {% include "trips/components/trip-cards-grid.html" with trips=upcoming_trips icon_type="upcoming" %}
+
+    {% include "trips/components/trip-cards-grid.html" with trips=owned_upcoming_trips icon_type="upcoming" %}
   </section>
-  
-  <!-- Past Trips Section -->
-  {% if past_trips %}
+
+  <!-- Shared Trips Section -->
+  {% if shared_trips %}
   <section class="mt-5">
-    <h2 class="h3 mb-3">Past Trips</h2>
-    {% include "trips/components/trip-cards-grid.html" with trips=past_trips icon_type="past" %}
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h2 class="h3 mb-0">Shared Trips</h2>
+    </div>
+    {% include "trips/components/trip-cards-grid.html" with trips=shared_trips icon_type="upcoming" %}
+  </section>
+  {% endif %}
+
+  <!-- Your Past Trips Section -->
+  {% if owned_past_trips %}
+  <section class="mt-5">
+    <h2 class="h3 mb-3">Your Past Trips</h2>
+    {% include "trips/components/trip-cards-grid.html" with trips=owned_past_trips icon_type="past" %}
   </section>
   {% endif %}
 </div>

--- a/src/tt/apps/dashboard/tests.py
+++ b/src/tt/apps/dashboard/tests.py
@@ -2,7 +2,7 @@ from django.test import TestCase, Client
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 
-from tt.apps.trips.enums import TripStatus
+from tt.apps.trips.enums import TripPermissionLevel, TripStatus
 from tt.apps.trips.tests.synthetic_data import TripSyntheticData
 
 
@@ -48,7 +48,7 @@ class DashboardViewTests(TestCase):
         response = self.client.get(self.dashboard_home_url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Test Trip')
-        self.assertEqual(len(response.context['upcoming_trips']), 1)
+        self.assertEqual(len(response.context['owned_upcoming_trips']), 1)
         self.assertEqual(response.context['total_trips'], 1)
 
     def test_dashboard_home_shows_past_trips(self):
@@ -69,8 +69,8 @@ class DashboardViewTests(TestCase):
 
         response = self.client.get(self.dashboard_home_url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context['upcoming_trips']), 1)
-        self.assertEqual(len(response.context['past_trips']), 1)
+        self.assertEqual(len(response.context['owned_upcoming_trips']), 1)
+        self.assertEqual(len(response.context['owned_past_trips']), 1)
         self.assertEqual(response.context['total_trips'], 2)
 
     def test_dashboard_home_only_shows_user_trips(self):
@@ -99,3 +99,96 @@ class DashboardViewTests(TestCase):
         self.assertEqual(response.context['total_trips'], 1)
         self.assertContains(response, 'My Trip')
         self.assertNotContains(response, 'Other User Trip')
+
+    def test_dashboard_categorizes_trips_by_ownership_and_status(self):
+        """Test that dashboard correctly categorizes trips by ownership and status."""
+        self.client.force_login(self.user)
+
+        # Create another user
+        other_user = User.objects.create_user(
+            email='other@example.com',
+            password='testpass123'
+        )
+
+        # Create owned upcoming trip
+        TripSyntheticData.create_test_trip(
+            user=self.user,
+            title='Owned Upcoming Trip',
+            trip_status=TripStatus.UPCOMING
+        )
+
+        # Create owned current trip (should be in owned_upcoming_trips)
+        TripSyntheticData.create_test_trip(
+            user=self.user,
+            title='Owned Current Trip',
+            trip_status=TripStatus.CURRENT
+        )
+
+        # Create owned past trip
+        TripSyntheticData.create_test_trip(
+            user=self.user,
+            title='Owned Past Trip',
+            trip_status=TripStatus.PAST
+        )
+
+        # Create shared upcoming trip (user is member but not owner)
+        shared_upcoming = TripSyntheticData.create_test_trip(
+            user=other_user,
+            title='Shared Upcoming Trip',
+            trip_status=TripStatus.UPCOMING
+        )
+        TripSyntheticData.add_trip_member(
+            trip=shared_upcoming,
+            user=self.user,
+            permission_level=TripPermissionLevel.EDITOR,
+            added_by=other_user
+        )
+
+        # Create shared current trip (should be in shared_trips)
+        shared_current = TripSyntheticData.create_test_trip(
+            user=other_user,
+            title='Shared Current Trip',
+            trip_status=TripStatus.CURRENT
+        )
+        TripSyntheticData.add_trip_member(
+            trip=shared_current,
+            user=self.user,
+            permission_level=TripPermissionLevel.VIEWER,
+            added_by=other_user
+        )
+
+        # Create shared past trip (not shown in any category per requirements)
+        shared_past = TripSyntheticData.create_test_trip(
+            user=other_user,
+            title='Shared Past Trip',
+            trip_status=TripStatus.PAST
+        )
+        TripSyntheticData.add_trip_member(
+            trip=shared_past,
+            user=self.user,
+            permission_level=TripPermissionLevel.EDITOR,
+            added_by=other_user
+        )
+
+        response = self.client.get(self.dashboard_home_url)
+        self.assertEqual(response.status_code, 200)
+
+        # Verify owned_upcoming_trips includes UPCOMING and CURRENT owned trips
+        owned_upcoming_trips = response.context['owned_upcoming_trips']
+        self.assertEqual(len(owned_upcoming_trips), 2)
+        owned_upcoming_titles = {trip.title for trip in owned_upcoming_trips}
+        self.assertEqual(owned_upcoming_titles, {'Owned Upcoming Trip', 'Owned Current Trip'})
+
+        # Verify shared_trips includes UPCOMING and CURRENT shared trips
+        shared_trips = response.context['shared_trips']
+        self.assertEqual(len(shared_trips), 2)
+        shared_titles = {trip.title for trip in shared_trips}
+        self.assertEqual(shared_titles, {'Shared Upcoming Trip', 'Shared Current Trip'})
+
+        # Verify owned_past_trips includes only PAST owned trips
+        owned_past_trips = response.context['owned_past_trips']
+        self.assertEqual(len(owned_past_trips), 1)
+        self.assertEqual(owned_past_trips[0].title, 'Owned Past Trip')
+
+        # Verify total_trips count includes all trips (owned + shared)
+        self.assertEqual(response.context['total_trips'], 6)


### PR DESCRIPTION
## Pull Request: Dashboard Trips Ownership Categorization

### Issue Link

Closes #73

---

## Category

- [x] **Feature** (New functionality)
- [ ] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ] **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code/Style improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary

- Refactored DashboardView to categorize trips by ownership and status
- Added three trip sections: "Your Upcoming Trips", "Shared Trips", "Your Past Trips"
- Implemented efficient single-query approach using TripMember with select_related
- Updated dashboard template to display ownership-based trip categorization
- Added comprehensive tests for ownership-based trip filtering

---

## How to Test

1. Log in as a user with both owned and shared trips
2. Navigate to the dashboard page
3. Verify three sections appear:
   - "Your Upcoming Trips" showing trips where user is owner with UPCOMING/CURRENT status
   - "Shared Trips" showing trips where user is member but not owner with UPCOMING/CURRENT status
   - "Your Past Trips" showing trips where user is owner with PAST status
4. Verify empty sections are hidden when no trips exist for that category
5. Run test suite to verify all ownership categorization scenarios

---

## Checklist

- [x] Code follows the project's style guidelines.
- [x] Unit tests added or updated if necessary.
- [x] All tests pass (`./manage.py test`).
- [x] Docs updated if applicable.
- [x] No breaking changes introduced.

---

### **Ready for Review?**
- [x] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**

@cassandra
