### PR TITLE
feature/76-journal-date-change

### DIFF
--- a/src/tt/apps/journal/templates/journal/modals/date_changed.html
+++ b/src/tt/apps/journal/templates/journal/modals/date_changed.html
@@ -1,0 +1,33 @@
+{% extends "modals/action_2.html" %}
+{% load static %}
+{% load icons %}
+
+{% block modal_dialog_id %}date-changed-modal{% endblock %}
+
+{% block title_image %}
+<img class="img-fluid"
+     src="{% static 'img/tt-on-primary-icon-196x196.png' %}"
+     alt="Trip Tools Icon" \>
+{% endblock %}
+
+{% block title_text %}Date Changed{% endblock %}
+
+{% block body %}
+<p>You have changed the journal entry date. To see the updated sidebar navigation and entry order, please refresh the page.</p>
+<p class="mb-0"><strong>Your changes have been saved.</strong></p>
+{% endblock %}
+
+{% block action_left %}
+<button type="button" class="btn btn-secondary" data-dismiss="modal">
+  {% icon "cancel" size="sm" css_class="tt-icon-left" %}
+  Continue Editing
+</button>
+{% endblock %}
+
+{% block action_right %}
+<button type="button" class="btn btn-primary"
+        onclick="window.location.href = window.location.pathname + '?_=' + Date.now();">
+  {% icon "sync" size="sm" css_class="tt-icon-left" %}
+  Refresh Now
+</button>
+{% endblock %}

--- a/src/tt/apps/journal/tests/test_managers.py
+++ b/src/tt/apps/journal/tests/test_managers.py
@@ -444,6 +444,14 @@ class JournalManagerEdgeCasesTestCase(TestCase):
         self.assertIn('15', entry.title)
         self.assertIn('2025', entry.title)
 
+    def test_journal_entry_generate_default_title(self):
+        """JournalEntry.generate_default_title returns correct format."""
+        from datetime import date
+
+        test_date = date(2025, 11, 25)  # A Tuesday
+        title = JournalEntry.generate_default_title(test_date)
+        self.assertEqual(title, 'Tuesday, November 25, 2025')
+
     def test_journal_str_representation(self):
         """Journal __str__ should return meaningful string."""
         journal = Journal.objects.create(

--- a/src/tt/static/js/antinode.js
+++ b/src/tt/static/js/antinode.js
@@ -287,9 +287,21 @@
             });
         },
         
-        addAfterAsyncRenderFunction: addAfterAsyncRenderFunction
+        addAfterAsyncRenderFunction: addAfterAsyncRenderFunction,
+
+        // Display modal content that was rendered server-side.
+        // Creates a modal wrapper, appends the content, and shows it.
+        //
+        // Usage:
+        //   AN.displayModal('<div class="modal-dialog">...</div>');
+        //
+        displayModal: function( modalContent ) {
+            let targetObj = getNewModal();
+            targetObj.append( modalContent );
+            showModal( targetObj );
+        }
     }
-    
+
     window.AN = AN;
 
 //====================


### PR DESCRIPTION
## Pull Request: Improved Journal Entry Date Change Handling

### Issue Link
Closes #76

---

## Category
- [x] **Feature** (New functionality)
- [ ] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ] **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary
- **Auto-regenerate title when date changes**: If the entry title still matches the default pattern for the old date, it automatically updates to match the new date
- **Date change modal**: When a user changes the journal entry date, displays a modal asking if they want to refresh the page to update sidebar navigation and image picker
- **Immediate save on date changes**: Date changes trigger immediate autosave (no 2-second delay) via both picker selection and blur events
- **ENTER key handling**: Prevents form submission when ENTER is pressed in title/date fields, triggers immediate save instead
- **Enhanced backend response**: Autosave view returns `date_changed` and `title_updated` flags with rendered modal template
- **Smart input detection**: Distinguishes between date picker selection and keyboard input to provide appropriate UX

### Key Implementation Details
- Added `JournalEntry.generate_default_title()` classmethod as single source of truth for title generation
- Enhanced `JournalEntryAutosaveView` with date change detection and title auto-regeneration logic
- Created server-side modal template `journal/modals/date_changed.html` following project patterns
- Added `AN.displayModal()` to antinode.js to expose modal functionality
- Updated JavaScript event handlers with typing detection to handle both picker and keyboard input gracefully

---

## How to Test
1. **Auto-title regeneration**: Create a new journal entry (gets default title), change the date, verify title updates automatically
2. **Date change modal**: Change any journal entry date, verify modal appears asking to refresh page
3. **Immediate save**: Change date via picker or typing, verify immediate save without waiting for 2-second debounce
4. **ENTER key handling**: Press ENTER in title or date fields, verify immediate save instead of form submission
5. **Input method detection**: Type in date field components vs use picker dropdowns, verify appropriate save behavior

---

## Checklist
- [x] Code follows the project's style guidelines.
- [x] Unit tests added or updated if necessary.
- [x] All tests pass (`./manage.py test`).
- [ ] Docs updated if applicable.
- [x] No breaking changes introduced.

---

## Related PRs

---

## Screenshots (if applicable)

---

## Additional Notes
This feature addresses all the UI synchronization issues when journal entry dates change by providing a user-friendly modal prompt for page refresh rather than complex partial DOM updates that could disrupt active editing.

The implementation maintains backward compatibility and follows established patterns in the codebase for modal handling and autosave functionality.

---

### **Ready for Review?**
- [x] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**
@cassandra
