### PR TITLE
Journal Prologues and Epilogues Feature

### DIFF
--- a/src/tt/apps/images/views.py
+++ b/src/tt/apps/images/views.py
@@ -15,7 +15,6 @@ from django.views.generic import View
 from tt.apps.common.antinode import http_response
 from tt.apps.dashboard.context import DashboardPageContext
 from tt.apps.dashboard.enums import DashboardPage
-from tt.apps.journal.models import JournalEntry
 from tt.apps.members.models import TripMember
 from tt.apps.trips.context import TripPageContext
 from tt.apps.trips.enums import TripPage
@@ -571,13 +570,13 @@ class EntityImagePickerView(LoginRequiredMixin, TripViewMixin, ModalView, ABC):
 
         The fallback is enabled when:
         - No explicit date parameter is provided in the request, AND
-        - No existing reference image with datetime_utc is set, AND
-        - Entity is NOT a JournalEntry
+        - No existing reference image with datetime_utc is set
 
         The fallback is disabled when:
         - Explicit date parameter is provided (user is browsing dates), OR
-        - Existing reference image with UTC date is set (use that date), OR
-        - Entity is a JournalEntry (entries have specific dates, no fallback)
+        - Existing reference image with UTC date is set (use that date)
+
+        Subclasses may override this to provide entity-specific fallback logic.
 
         Args:
             entity: The entity (Trip, JournalEntry, etc.)
@@ -592,10 +591,6 @@ class EntityImagePickerView(LoginRequiredMixin, TripViewMixin, ModalView, ABC):
 
         # Disable fallback if existing reference image with UTC date
         if entity.reference_image and entity.reference_image.datetime_utc:
-            return False
-
-        # Disable fallback for JournalEntry entities (they have specific dates)
-        if isinstance(entity, JournalEntry):
             return False
 
         # Enable fallback in all other cases

--- a/src/tt/apps/journal/autosave_helpers.py
+++ b/src/tt/apps/journal/autosave_helpers.py
@@ -13,13 +13,16 @@ from typing import Optional, Tuple
 from uuid import UUID
 
 from django.contrib.auth import get_user_model
+from django.db import IntegrityError, DatabaseError
 from django.http import HttpRequest, JsonResponse
+from django.template.loader import render_to_string
 
 from tt.apps.common.autosave_helpers import AutoSaveHelper as SharedAutoSaveHelper, ConflictHelper
 from tt.apps.common.html_sanitizer import sanitize_rich_text_html
 from tt.apps.images.models import TripImage
 
 from .models import JournalEntry
+
 
 User = get_user_model()
 logger = logging.getLogger(__name__)
@@ -34,6 +37,164 @@ class JournalAutoSaveRequest:
     new_title                : Optional[str]
     new_timezone             : Optional[str]
     new_reference_image_uuid : Optional[str]
+
+
+@dataclass
+class DateChangeResult:
+    """Result of processing date change with title auto-generation."""
+    date_changed    : bool
+    title_updated   : bool
+    final_title     : Optional[str]
+    final_date      : Optional[date_class]
+
+
+class DateChangeOrchestrator:
+    """
+    Handles date change detection and title auto-regeneration business rules.
+
+    Business Rule: When the date of a journal entry changes, if the current title
+    matches the default pattern for the OLD date, auto-regenerate the title for
+    the new date. This provides a seamless experience when users change dates
+    but haven't customized the title.
+    """
+
+    @classmethod
+    def process_date_change( cls,
+                             entry     : 'JournalEntry',
+                             new_date  : Optional[date_class],
+                             new_title : Optional[str]) -> DateChangeResult:
+        """
+        Process date change with title auto-regeneration business rules.
+
+        Args:
+            entry: Current journal entry being edited
+            new_date: Requested new date (None = no date change requested)
+            new_title: Requested new title (None = no title change requested)
+
+        Returns:
+            DateChangeResult with computed values for date_changed, title_updated,
+            final_title, and final_date
+        """
+        original_date = entry.date
+        original_title = entry.title
+
+        # Default to no changes
+        date_changed = False
+        title_updated = False
+        final_title = new_title
+        final_date = None
+
+        # Process date change
+        if new_date and ( new_date != original_date ):
+            date_changed = True
+            final_date = new_date
+
+            # Auto-regenerate title if it matches old date's default pattern
+            sent_title = new_title or original_title
+            if JournalAutoSaveHelper.is_default_title_for_date(sent_title, original_date):
+                final_title = JournalEntry.generate_default_title(new_date)
+                title_updated = True
+
+        return DateChangeResult(
+            date_changed = date_changed,
+            title_updated = title_updated,
+            final_title = final_title,
+            final_date = final_date,
+        )
+
+
+class AutosaveResponseBuilder:
+    """
+    Builds JSON responses for autosave operations.
+
+    Centralizes response format knowledge and handles optional modal rendering
+    for date-changed notifications.
+    """
+
+    @classmethod
+    def build_success_response( cls,
+                                request         : HttpRequest,
+                                updated_entry   : 'JournalEntry',
+                                date_changed    : bool,
+                                title_updated   : bool) -> JsonResponse:
+        """
+        Build successful autosave JSON response with optional modal.
+
+        Args:
+            request: HTTP request for template rendering context
+            updated_entry: Successfully updated journal entry
+            date_changed: Whether date was modified during save
+            title_updated: Whether title was auto-regenerated
+
+        Returns:
+            JsonResponse with success status and metadata
+        """
+        response_data = {
+            'status': 'success',
+            'version': updated_entry.edit_version,
+            'modified_datetime': updated_entry.modified_datetime.isoformat(),
+            'date_changed': date_changed,
+            'title_updated': title_updated,
+        }
+
+        # Include date change notification modal
+        if date_changed:
+            response_data['modal'] = render_to_string(
+                'journal/modals/date_changed.html',
+                {},
+                request = request
+            )
+
+        return JsonResponse(response_data)
+
+
+class ExceptionResponseBuilder:
+    """
+    Centralized exception handling for autosave operations.
+
+    Converts exceptions to appropriate JSON error responses with consistent
+    logging and status codes.
+    """
+
+    @classmethod
+    def handle_autosave_exception( cls,
+                                   exception : Exception,
+                                   entry     : 'JournalEntry') -> JsonResponse:
+        """
+        Convert autosave exception to appropriate JSON error response.
+
+        Args:
+            exception: Exception that occurred during autosave
+            entry: Journal entry being saved (for logging context)
+
+        Returns:
+            JsonResponse with appropriate error status and message
+        """
+        if isinstance(exception, JournalEntry.DoesNotExist):
+            logger.error(f'Entry {entry.pk} not found during atomic update')
+            return JsonResponse(
+                {'status': 'error', 'message': 'Entry not found'},
+                status = 404
+            )
+        elif isinstance(exception, IntegrityError):
+            logger.warning(f'Integrity constraint violation for entry {entry.pk}: {exception}')
+            return JsonResponse(
+                {'status': 'error', 'message': 'Unable to save - entry date conflicts with another entry'},
+                status = 409
+            )
+        elif isinstance(exception, DatabaseError):
+            logger.error(f'Database error auto-saving journal entry {entry.pk}: {exception}')
+            return JsonResponse(
+                {'status': 'error', 'message': 'Database error occurred'},
+                status = 500
+            )
+        else:
+            # Unexpected exception - log full details
+            logger.error(f'Unexpected error in autosave for entry {entry.pk}: {exception}', exc_info=True)
+            return JsonResponse(
+                {'status': 'error', 'message': 'An unexpected error occurred'},
+                status = 500
+            )
 
 
 class JournalConflictHelper:
@@ -131,20 +292,36 @@ class JournalAutoSaveHelper:
             return ''
 
     @classmethod
-    def validate_date_uniqueness(cls,
-                                 entry: JournalEntry,
-                                 new_date: date_class) -> Optional[JsonResponse]:
-        if new_date and new_date != entry.date:
-            existing = JournalEntry.objects.filter(
-                journal=entry.journal,
-                date=new_date
-            ).exclude(pk=entry.pk).exists()
-
-            if existing:
+    def validate_date_uniqueness( cls,
+                                  entry     : JournalEntry,
+                                  new_date  : date_class) -> Optional[JsonResponse]:
+        if new_date and ( new_date != entry.date ):
+            # Prevent date changes on special entries (prologue/epilogue)
+            if entry.is_special_entry:
                 return JsonResponse(
                     {
                         'status': 'error',
-                        'message': f'An entry for {new_date.strftime("%B %d, %Y")} already exists.'
+                        'message': f'Cannot change the date of the {entry.page_type.label}.'
+                    },
+                    status=400
+                )
+
+            # Check for duplicate dates
+            existing_entry = JournalEntry.objects.filter(
+                journal=entry.journal,
+                date=new_date
+            ).exclude(pk=entry.pk).first()
+
+            if existing_entry:
+                if existing_entry.is_special_entry:
+                    error_message = f'The {existing_entry.page_type.label} already exists.'
+                else:
+                    error_message = f'An entry for {existing_entry.display_date_medium} already exists.'
+
+                return JsonResponse(
+                    {
+                        'status': 'error',
+                        'message': error_message
                     },
                     status=400
                 )

--- a/src/tt/apps/journal/context.py
+++ b/src/tt/apps/journal/context.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from django.db.models import QuerySet
 
-from .models import Journal
+from .models import Journal, JournalEntry
 
 
 @dataclass
@@ -18,10 +18,14 @@ class JournalPageContext:
         journal_entry_uuid: UUID of the currently viewed JournalEntry.
                            Used to highlight the active entry in sidebar.
                            None when on the list view.
+        has_prologue: Boolean indicating if journal has a prologue entry.
+        has_epilogue: Boolean indicating if journal has an epilogue entry.
     """
     journal            : Journal
     journal_entries    : Optional[QuerySet]        = None
     journal_entry_uuid : Optional[Union[UUID, str]] = None
+    has_prologue       : bool                      = False
+    has_epilogue       : bool                      = False
 
     def __post_init__(self):
         # Convert string to UUID if needed, validate format
@@ -32,4 +36,30 @@ class JournalPageContext:
                 except (ValueError, TypeError):
                     self.journal_entry_uuid = None
         return
+
+    @classmethod
+    def create( cls,
+                journal          : Optional[Journal],
+                journal_entries  : Optional[QuerySet]        = None,
+                journal_entry_uuid : Optional[Union[UUID, str]] = None ) -> 'JournalPageContext':
+        """
+        Factory method to create context with computed special entry flags.
+
+        This computes has_prologue and has_epilogue based on the journal's entries,
+        avoiding the need for callers to manage these flags separately.
+        """
+        has_prologue = False
+        has_epilogue = False
+
+        if journal:
+            has_prologue = JournalEntry.objects.has_prologue(journal)
+            has_epilogue = JournalEntry.objects.has_epilogue(journal)
+
+        return cls(
+            journal = journal,
+            journal_entries = journal_entries,
+            journal_entry_uuid = journal_entry_uuid,
+            has_prologue = has_prologue,
+            has_epilogue = has_epilogue,
+        )
     

--- a/src/tt/apps/journal/enums.py
+++ b/src/tt/apps/journal/enums.py
@@ -72,3 +72,11 @@ class JournalTheme(LabeledEnum):
     def default(cls):
         """Default theme for new journals."""
         return JournalTheme.DEFAULT
+
+    
+class EntryPageType(LabeledEnum):
+
+    DATED     = ( 'Dated'     , 'Journal entries with a date.' )
+    PROLOGUE  = ( 'Prologue'  , 'Journal entries that are prologue.' )
+    EPILOGUE  = ( 'Epilogue'  , 'Journal entries that are epilogue.' )
+    

--- a/src/tt/apps/journal/managers.py
+++ b/src/tt/apps/journal/managers.py
@@ -1,19 +1,15 @@
+from datetime import date as date_class
 from typing import TYPE_CHECKING, Optional
 
 from django.db import models
 
 if TYPE_CHECKING:
-    from .models import Journal
+    from .models import Journal, JournalEntry
 
 
 class JournalManager(models.Manager):
-    """Manager for Journal model."""
 
     def for_trip(self, trip) -> models.QuerySet:
-        """
-        Get all journals for a specific trip.
-        Returns QuerySet (may be empty).
-        """
         return self.filter(trip = trip)
 
     def get_primary_for_trip(self, trip) -> Optional['Journal']:
@@ -28,8 +24,19 @@ class JournalManager(models.Manager):
 
 
 class JournalEntryManager(models.Manager):
-    """Manager for JournalEntry model."""
 
     def for_journal(self, journal) -> models.QuerySet:
-        """Get all entries for a specific journal."""
         return self.filter(journal = journal)
+
+    def get_prologue(self, journal) -> Optional['JournalEntry']:
+        return self.filter(journal=journal, date=date_class.min).first()
+
+    def get_epilogue(self, journal) -> Optional['JournalEntry']:
+        from datetime import date as date_class
+        return self.filter(journal=journal, date=date_class.max).first()
+
+    def has_prologue(self, journal) -> bool:
+        return self.filter(journal=journal, date=date_class.min).exists()
+
+    def has_epilogue(self, journal) -> bool:
+        return self.filter(journal=journal, date=date_class.max).exists()

--- a/src/tt/apps/journal/mixins.py
+++ b/src/tt/apps/journal/mixins.py
@@ -25,7 +25,7 @@ class JournalViewMixin:
         else:
             journal_entries = JournalEntry.objects.none()
             publishing_status = None
-        journal_page_context = JournalPageContext(
+        journal_page_context = JournalPageContext.create(
             journal = journal,
             journal_entries = journal_entries,
         )

--- a/src/tt/apps/journal/templates/journal/components/journal_editor_multi_image_picker.html
+++ b/src/tt/apps/journal/templates/journal/components/journal_editor_multi_image_picker.html
@@ -22,12 +22,12 @@
           class="form-control form-control-sm flex-grow-1"
           id="{{ DIVID.JOURNAL_EDITOR_MULTI_IMAGE_DATE_INPUT_ID }}"
           name="date"
-          value="{{ entry.date|date:'Y-m-d' }}"
+          {% if not is_recent_mode %}value="{{ entry.date|date:'Y-m-d' }}"{% endif %}
           onchange-async="true"
       >
       <button
           type="button"
-          class="btn btn-sm btn-outline-primary ml-1"
+          class="btn btn-sm {% if is_recent_mode %}btn-primary{% else %}btn-outline-primary{% endif %} ml-1"
           id="{{ DIVID.JOURNAL_EDITOR_MULTI_IMAGE_RECENT_BTN_ID }}"
           title="Show recently uploaded images">
         Recent

--- a/src/tt/apps/journal/templates/journal/modals/journal_entry_delete.html
+++ b/src/tt/apps/journal/templates/journal/modals/journal_entry_delete.html
@@ -13,7 +13,7 @@
   <strong>Are you sure you want to delete this journal entry?</strong>
 </div>
 <p>
-  This will permanently delete the journal entry for <strong>{{ journal_entry.date|date:"F j, Y" }}</strong>.
+  This will permanently delete the journal entry for <strong>{{ journal_entry.display_date_long }}</strong>.
   {% if journal_entry.text %}
   All content will be lost.
   {% endif %}

--- a/src/tt/apps/journal/templates/journal/pages/journal.html
+++ b/src/tt/apps/journal/templates/journal/pages/journal.html
@@ -254,14 +254,10 @@
           <div class="d-flex w-100 justify-content-between align-items-start">
             <div>
               <h5 class="mb-1">
-                {% if entry.title %}
-                {{ entry.title }}
-                {% else %}
-                {{ entry.date|date:'l, F j, Y' }}
-                {% endif %}
+                {{ entry.title|default:entry.display_date_long }}
               </h5>
               {% if entry.text %}
-              <small class="text-muted">{{ entry.date|date:'l, F j, Y' }}</small>
+              <small class="text-muted">{{ entry.display_date_long }}</small>
               {% else %}
               <p class="mb-0 text-muted"><em>Empty entry</em></p>
               {% endif %}

--- a/src/tt/apps/journal/templates/journal/pages/journal_base.html
+++ b/src/tt/apps/journal/templates/journal/pages/journal_base.html
@@ -15,10 +15,18 @@
 
 {% block sidebar_nav_items %}
 {% if journal_page.journal_entries %}
+{% if trip_page.request_member.can_edit_trip and not journal_page.has_prologue %}
+<li>
+  <a href="{% url 'journal_prologue_new' journal_uuid=journal_page.journal.uuid %}" class="text-muted">
+    {% icon "plus" size="sm" css_class="tt-icon-left" %}
+    <span>Add Prologue</span>
+  </a>
+</li>
+{% endif %}
 {% for entry in journal_page.journal_entries %}
 <li>
   <a href="{% url 'journal_entry' entry_uuid=entry.uuid %}"{% if entry.uuid == journal_page.journal_entry_uuid %} class="active" aria-current="page"{% endif %}>
-    {{ entry.date|date:'D, M j' }}
+    {{ entry.display_date_short }}
   </a>
 </li>
 {% endfor %}
@@ -26,9 +34,17 @@
 <li>
   <a href="{% url 'journal_entry_new' journal_uuid=journal_page.journal.uuid %}" class="text-muted">
     {% icon "plus" size="sm" css_class="tt-icon-left" %}
-    <span>New Entry</span>
+    <span>Add New Day</span>
       </a>
 </li>
+{% if not journal_page.has_epilogue %}
+<li>
+  <a href="{% url 'journal_epilogue_new' journal_uuid=journal_page.journal.uuid %}" class="text-muted">
+    {% icon "plus" size="sm" css_class="tt-icon-left" %}
+    <span>Add Epilogue</span>
+  </a>
+</li>
+{% endif %}
 {% else %}
 <li><em>No Journal Entries</em></li>
 {% endif %}

--- a/src/tt/apps/journal/templates/journal/pages/journal_entry.html
+++ b/src/tt/apps/journal/templates/journal/pages/journal_entry.html
@@ -89,6 +89,11 @@
             </div>
 
             <!-- Date and Timezone (inline in second row) -->
+            {% if entry.is_special_entry %}
+            <div class="form-inline">
+              <label class="font-weight-bold h4 mr-2">{{ entry.page_type.label }}</label>
+            </div>
+            {% else %}
             <div class="form-inline">
               <label for="{{ DIVID.JOURNAL_DATE_INPUT_ID }}" class="font-weight-bold mr-2">Date:</label>
               <input
@@ -101,6 +106,7 @@
               <small class="text-muted mr-2">({{ entry.date|date:"l" }})</small>
               {{ journal_entry_form.timezone }}
             </div>
+            {% endif %}
           </div>
 
           <div class="d-flex justify-content-end align-items-center mt-4">

--- a/src/tt/apps/journal/urls.py
+++ b/src/tt/apps/journal/urls.py
@@ -64,6 +64,16 @@ urlpatterns = [
         name='journal_entry_new'
     ),
     path(
+        '<uuid:journal_uuid>/entry/prologue/new/',
+        views.JournalPrologueNewView.as_view(),
+        name='journal_prologue_new'
+    ),
+    path(
+        '<uuid:journal_uuid>/entry/epilogue/new/',
+        views.JournalEpilogueNewView.as_view(),
+        name='journal_epilogue_new'
+    ),
+    path(
         'entry/<uuid:entry_uuid>',
         views.JournalEntryView.as_view(),
         name='journal_entry'

--- a/src/tt/apps/journal/utils.py
+++ b/src/tt/apps/journal/utils.py
@@ -18,6 +18,10 @@ class JournalUtils:
         Returns the full local day boundaries, which may be 23, 24, or 25 hours
         depending on DST transitions in the specified timezone.
 
+        For extreme dates (date.min, date.max) used as sentinel values for
+        prologue/epilogue entries, returns an empty range (start == end) to
+        signal that no date-based filtering should occur.
+
         Args:
             entry_date: datetime.date object for the journal entry
             timezone_str: pytz timezone string (e.g., 'America/New_York')
@@ -25,6 +29,7 @@ class JournalUtils:
         Returns:
             tuple: (start_datetime, end_datetime) as timezone-aware datetimes
             representing midnight to midnight in the local timezone.
+            Returns empty range for extreme dates.
 
         Example:
             date = date(2025, 1, 15)
@@ -33,6 +38,13 @@ class JournalUtils:
             # start = 2025-01-15 00:00:00-05:00
             # end = 2025-01-16 00:00:00-05:00
         """
+        # Handle extreme dates that would cause overflow in date arithmetic.
+        # These sentinel values (date.min, date.max) are used for prologue/epilogue
+        # entries. Return an empty range so callers get no date-based results.
+        if entry_date == date_type.min or entry_date == date_type.max:
+            utc_now = datetime.now(pytz.UTC)
+            return utc_now, utc_now
+
         tz = pytz.timezone(timezone_str)
 
         # Start of day in entry timezone

--- a/src/tt/apps/travelog/templates/travelog/pages/travelog_day.html
+++ b/src/tt/apps/travelog/templates/travelog/pages/travelog_day.html
@@ -1,7 +1,7 @@
 {% extends "travelog/pages/base.html" %}
 {% load travelog_tags %}
 
-{% block head_title %}{{ content.title }} - {{ entry.date }}{% endblock %}
+{% block head_title %}{{ content.title }} - {{ entry.display_date_medium }}{% endblock %}
 
 {% block travelog_content %}
 <div class="container">
@@ -11,7 +11,7 @@
     </a>
   </nav>
 
-  <h1>{{ entry.date|date:"F j, Y" }}</h1>
+  <h1>{{ entry.display_date_medium }}</h1>
   {% if entry.title %}
   <h2>{{ entry.title }}</h2>
   {% endif %}
@@ -27,7 +27,7 @@
   <div class="page-navigation">
     {% if prev_entry %}
     <a href="{% travelog_url 'travelog_day' journal.uuid date=prev_entry.date version=request.GET.version %}" class="nav-link">
-      &larr; Previous: {{ prev_entry.date|date:"F j" }}
+      &larr; Previous: {{ prev_entry.display_date_nav }}
     </a>
     {% else %}
     <span></span>
@@ -35,7 +35,7 @@
 
     {% if next_entry %}
     <a href="{% travelog_url 'travelog_day' journal.uuid date=next_entry.date version=request.GET.version %}" class="nav-link">
-      Next: {{ next_entry.date|date:"F j" }} &rarr;
+      Next: {{ next_entry.display_date_nav }} &rarr;
     </a>
     {% else %}
     <span></span>

--- a/src/tt/apps/travelog/templates/travelog/pages/travelog_toc.html
+++ b/src/tt/apps/travelog/templates/travelog/pages/travelog_toc.html
@@ -45,7 +45,7 @@
           {% endif %}
           <div class="card-content">
             <h3 class="card-title">
-              {{ entry.date|date:"F j" }}{% if entry.title %} - {{ entry.title }}{% endif %}
+              {{ entry.display_date_nav }}{% if entry.title %} - {{ entry.title }}{% endif %}
             </h3>
             {% if entry.text %}
             <p class="card-description">

--- a/src/tt/static/js/journal-editor.js
+++ b/src/tt/static/js/journal-editor.js
@@ -4529,7 +4529,8 @@
     }
 
     // Track current mode (recent or date)
-    var currentMode = 'date'; // Start in date mode
+    // Detect initial mode from DOM: empty date input means recent mode
+    var currentMode = $dateInput.val() ? 'date' : 'recent';
 
     /**
      * Update visual state of Recent button


### PR DESCRIPTION
## Pull Request: Journal Prologues and Epilogues Feature

### Issue Link
Closes #77

---

## Category
- [x] **Feature** (New functionality)
- [ ] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ] **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary
- Added support for special journal entry types: Prologue and Epilogue
- Implemented `EntryPageType` enum as single source of truth for entry type labels
- Added `is_special_entry`, `is_prologue`, `is_epilogue` properties to journal entries
- Added `page_type` property that returns appropriate `EntryPageType` enum value
- Added multiple date display properties: `display_date_short`, `display_date_medium`, `display_date_nav`, `display_date_long`
- Updated all templates to use new properties instead of conditional logic
- Refactored `JournalEntryAutosaveView` using helper classes for better organization
- Fixed OverflowError for prologue/epilogue entries in image picker by handling extreme dates
- Fixed image picker UI for special entries: empty date input and active "Recent" button state
- Updated date validation and title auto-generation to support special entries

---

## How to Test
1. Navigate to a journal and create a new entry
2. Try changing the date to minimum/maximum values to create prologue/epilogue
3. Verify special entries show "Prologue"/"Epilogue" instead of dates in navigation
4. Test image picker on special entries - should show empty date and active Recent button
5. Verify autosave works correctly with date changes and title auto-generation
6. Test that special entries cannot have their dates changed
7. Run full test suite to verify no regressions

---

## Checklist
- [x] Code follows the project's style guidelines.
- [x] Unit tests added or updated if necessary.
- [x] All tests pass (`./manage.py test`).
- [x] Docs updated if applicable.
- [x] No breaking changes introduced.

---

## Related PRs
N/A

---

## Screenshots (if applicable)
N/A

---

## Additional Notes
This feature adds support for journal prologue and epilogue entries using sentinel dates (date.min/date.max). The implementation includes proper handling of edge cases in date arithmetic, image picker integration, and maintains clean module boundaries between apps.

---

### **Ready for Review?**
- [x] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**
@cassandra
