### PR TITLE
Improved client-server share of identifiers with TtConst

### DIFF
--- a/src/tt/apps/travelog/services.py
+++ b/src/tt/apps/travelog/services.py
@@ -172,20 +172,20 @@ class TravelogImageCacheService:
     # Regex pattern for extracting image UUIDs from HTML
     # Matches: <img class="...trip-image..." data-uuid="{UUID}" ...>
     IMAGE_UUID_PATTERN = re.compile(
-        r'<img' + HtmlRegexPatterns.ANY_ATTRS +
-        HtmlRegexPatterns.class_containing(TtConst.JOURNAL_IMAGE_CLASS) +
-        HtmlRegexPatterns.ANY_ATTRS +
-        HtmlRegexPatterns.uuid_capture('data-' + TtConst.UUID_DATA_ATTR),
+        r'<img' + HtmlRegexPatterns.ANY_ATTRS
+        + HtmlRegexPatterns.class_containing(TtConst.JOURNAL_IMAGE_CLASS)
+        + HtmlRegexPatterns.ANY_ATTRS
+        + HtmlRegexPatterns.uuid_capture('data-' + TtConst.UUID_DATA_ATTR),
         re.IGNORECASE
     )
 
     # Regex pattern for extracting layout from wrapper
     # Matches: <span class="...trip-image-wrapper..." data-layout="{LAYOUT}">
     LAYOUT_PATTERN = re.compile(
-        r'<span' + HtmlRegexPatterns.ANY_ATTRS +
-        HtmlRegexPatterns.class_containing(TtConst.JOURNAL_IMAGE_WRAPPER_CLASS) +
-        HtmlRegexPatterns.ANY_ATTRS +
-        HtmlRegexPatterns.attr_capture('data-' + TtConst.LAYOUT_DATA_ATTR),
+        r'<span' + HtmlRegexPatterns.ANY_ATTRS
+        + HtmlRegexPatterns.class_containing(TtConst.JOURNAL_IMAGE_WRAPPER_CLASS)
+        + HtmlRegexPatterns.ANY_ATTRS
+        + HtmlRegexPatterns.attr_capture('data-' + TtConst.LAYOUT_DATA_ATTR),
         re.IGNORECASE
     )
 


### PR DESCRIPTION
## Pull Request: Improved client-server share of identifiers with TtConst

### Issue Link

Closes #88

---

## Category

- [ ] **Feature** (New functionality)
- [ ] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ] **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [x] **Refactor** (Code/Style improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary

- Replaced hardcoded string DIVID with new TtConst class for shared client/server identifiers
- Moved TtConst to regular class structure for better maintainability
- Updated documentation for new TtConst pattern for shared client/server strings
- Cleaned up, rationalized and normalized TtConst variables
- Fixed lint issues by moving binary operators to line start (W504)

---

## How to Test

1. Run the full test suite: `make test` (all 851 tests should pass)
2. Verify code quality: `make lint` (should have no output)
3. Check that client-server communication still works correctly with the new TtConst identifiers
4. Verify that the refactored code maintains the same functionality as before

---

## Checklist

- [x] Code follows the project's style guidelines.
- [x] Unit tests added or updated if necessary.
- [x] All tests pass (`./manage.py test`).
- [x] Docs updated if applicable.
- [x] No breaking changes introduced.

---

### **Ready for Review?**
- [x] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**

@cassandra
